### PR TITLE
Fix unstable Nodes ordering and drag-sort no-op

### DIFF
--- a/apps/admin/src/sections/nodes/index.tsx
+++ b/apps/admin/src/sections/nodes/index.tsx
@@ -278,7 +278,18 @@ export default function Nodes() {
           size: pagination.size,
           search: filter?.search || undefined,
         });
-        const list = (data?.data?.list || []) as API.Node[];
+        const rawList = (data?.data?.list || []) as API.Node[];
+        // Backend should ideally return nodes already sorted, but we also sort on the
+        // frontend to keep the UI stable (and avoid "random" order after refresh).
+        const list = rawList.slice().sort((a, b) => {
+          const as = a.sort;
+          const bs = b.sort;
+          const an = typeof as === "number" ? as : Number.POSITIVE_INFINITY;
+          const bn = typeof bs === "number" ? bs : Number.POSITIVE_INFINITY;
+          if (an !== bn) return an - bn;
+          // Tie-breaker to keep a stable order.
+          return Number(a.id) - Number(b.id);
+        });
         const total = Number(data?.data?.total || list.length);
         return { list, total };
       }}

--- a/packages/ui/src/composed/pro-table/wrapper.tsx
+++ b/packages/ui/src/composed/pro-table/wrapper.tsx
@@ -35,10 +35,16 @@ export function ProTableWrapper<TData extends { id?: string | number }>({
 
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
-    if (onSort) {
-      const updatedData = await onSort(active.id, over?.id || null, data);
-      setData(updatedData);
-    }
+
+    // If the pointer is released outside of any droppable row, `over` can be null.
+    // In that case we should keep the current order (and avoid firing a sort API call).
+    if (!(onSort && over)) return;
+
+    // No-op when dropping onto itself.
+    if (String(active.id) === String(over.id)) return;
+
+    const updatedData = await onSort(active.id, over.id, data);
+    setData(updatedData);
   };
   if (!onSort) return children;
   return (


### PR DESCRIPTION
- Sort nodes by `sort` (and tie-break by id) after fetch to keep UI stable even if backend returns unsorted list.\n- Avoid firing sort callback when drag ends outside droppable row or onto itself.\n\nFixes #11.