### PR TITLE
chore: add Cloudflare Pages API proxy and fix build dependency resolution

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.0.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "@lottiefiles/dotlottie-react": "^0.17.7",
     "@noble/curves": "^2.0.1",
     "@stripe/react-stripe-js": "^5.4.0",

--- a/apps/user/package.json
+++ b/apps/user/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.0.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "@lottiefiles/dotlottie-react": "^0.17.7",
     "@stripe/react-stripe-js": "^5.4.0",
     "@stripe/stripe-js": "^8.5.2",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,5 @@
+[install]
+# Use hoisted (flat) node_modules layout instead of isolated installs.
+# This ensures Vite/Rollup can resolve dependencies correctly in CI environments
+# such as Cloudflare Pages.
+linker = "hoisted"

--- a/functions/v1/[[path]].ts
+++ b/functions/v1/[[path]].ts
@@ -1,0 +1,63 @@
+interface Env {
+  API_BASE_URL: string;
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+
+  const apiBase = (env.API_BASE_URL || "https://api.ppanel.dev").replace(
+    /\/$/,
+    "",
+  );
+
+  const url = new URL(request.url);
+  const targetUrl = `${apiBase}${url.pathname}${url.search}`;
+
+  const headers = new Headers(request.headers);
+  headers.set("Host", new URL(apiBase).host);
+  headers.delete("cf-connecting-ip");
+  headers.delete("cf-ipcountry");
+  headers.delete("cf-ray");
+  headers.delete("cf-visitor");
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: "follow",
+  };
+
+  if (
+    request.method !== "GET" &&
+    request.method !== "HEAD" &&
+    request.body !== null
+  ) {
+    init.body = request.body;
+  }
+
+  const response = await fetch(targetUrl, init);
+
+  const responseHeaders = new Headers(response.headers);
+  responseHeaders.delete("set-cookie");
+  responseHeaders.set("Access-Control-Allow-Origin", url.origin);
+  responseHeaders.set(
+    "Access-Control-Allow-Methods",
+    "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+  );
+  responseHeaders.set(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization",
+  );
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: responseHeaders,
+    });
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
+};


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

**fix: Cloudflare Pages 构建与 API 代理支持 / Cloudflare Pages build compatibility & API proxy**

本次变更解决了在 Cloudflare Pages 环境下部署时遇到的依赖解析和跨域请求问题，具体包含以下三项改动：

1. **新增 `bunfig.toml`**
   将 Bun 的包安装模式设置为 `hoisted`（扁平化 `node_modules`），确保 Vite/Rollup 在 Cloudflare Pages CI 环境中能正确解析依赖。

2. **显式声明 React 依赖**
   在 `apps/admin` 和 `apps/user` 的 `package.json` 中分别添加 `react@^19.2.0` 和 `react-dom@^19.2.0`，避免 hoisted 模式下因隐式依赖提升失败导致构建报错。

3. **新增 Cloudflare Pages API 代理 `functions/v1/[[path]].ts`**
   实现了一个 Cloudflare Pages Function，将 `/v1/**` 路径的请求透明转发至后端（由环境变量 `API_BASE_URL` 指定），并处理 CORS 及 Cloudflare 专属请求头的清理，使前端无需额外跨域配置即可访问 API。

#### 📝 补充信息 | Additional Information

**Cloudflare Pages 部署配置 / Deployment Configuration**

| | Admin | User |
|---|---|---|
| **构建命令 Build command** | `bun install && bunx turbo build --filter=ppanel-admin-web` | `bun install && bunx turbo build --filter=ppanel-user-web` |
| **输出目录 Build output directory** | `apps/admin/dist` | `apps/user/dist` |

**环境变量 Environment Variables**

| 变量名 | 说明 | 默认值 |
|---|---|---|
| `API_BASE_URL` | 后端 API 地址 | `https://api.ppanel.dev` |

- `OPTIONS` 预检请求统一返回 `204`，确保浏览器 CORS 预检正常通过。
- 代理层已移除 `set-cookie` 响应头转发，避免 Cookie 属性不兼容问题。
