### PR TITLE
feat(servers): add Reality support for anytls; fix vless flow

### DIFF
--- a/apps/admin/src/sections/servers/form-schema/constants.ts
+++ b/apps/admin/src/sections/servers/form-schema/constants.ts
@@ -66,7 +66,7 @@ export const SECURITY = {
   trojan: ["tls"] as const,
   hysteria: ["tls"] as const,
   tuic: ["tls"] as const,
-  anytls: ["tls"] as const,
+  anytls: ["none", "tls", "reality"] as const,
   naive: ["none", "tls"] as const,
   http: ["none", "tls"] as const,
 } as const;
@@ -74,8 +74,6 @@ export const SECURITY = {
 export const FLOWS = {
   vless: [
     "none",
-    "xtls-rprx-direct",
-    "xtls-rprx-splice",
     "xtls-rprx-vision",
   ] as const,
 } as const;

--- a/apps/admin/src/sections/servers/form-schema/defaults.ts
+++ b/apps/admin/src/sections/servers/form-schema/defaults.ts
@@ -184,6 +184,11 @@ export function getProtocolDefaultConfig(proto: ProtocolType) {
         cert_mode: "none",
         cert_dns_provider: null,
         cert_dns_env: null,
+        reality_server_addr: null,
+        reality_server_port: null,
+        reality_private_key: null,
+        reality_public_key: null,
+        reality_short_id: null,
         ratio: 1,
       } as any;
     default:

--- a/apps/admin/src/sections/servers/form-schema/schemas.ts
+++ b/apps/admin/src/sections/servers/form-schema/schemas.ts
@@ -156,6 +156,11 @@ const anytls = z.object({
   cert_mode: z.enum(CERT_MODES).nullish(),
   cert_dns_provider: nullableString,
   cert_dns_env: nullableString,
+  reality_server_addr: nullableString,
+  reality_server_port: nullablePort,
+  reality_private_key: nullableString,
+  reality_public_key: nullableString,
+  reality_short_id: nullableString,
 });
 
 const socks = z.object({

--- a/apps/admin/src/sections/servers/form-schema/useProtocolFields.ts
+++ b/apps/admin/src/sections/servers/form-schema/useProtocolFields.ts
@@ -279,7 +279,10 @@ export function useProtocolFields() {
           options: FLOWS.vless,
           defaultValue: "none",
           group: "transport",
-          condition: (p) => p.transport === "tcp",
+          condition: (p) =>
+            p.encryption === "mlkem768x25519plus" ||
+            (p.transport === "tcp" &&
+              (p.security === "tls" || p.security === "reality")),
         },
         {
           name: "security",
@@ -441,7 +444,7 @@ export function useProtocolFields() {
           name: "encryption_ticket",
           type: "input",
           label: t("encryption_ticket", "Ticket Time"),
-          placeholder: "e.g. 600s",
+          placeholder: "e.g. 600",
           group: "encryption",
           condition: (p) =>
             p.encryption === "mlkem768x25519plus" &&
@@ -1094,6 +1097,14 @@ export function useProtocolFields() {
           group: "basic",
         },
         {
+          name: "security",
+          type: "select",
+          label: t("security", "Security"),
+          options: SECURITY.anytls,
+          defaultValue: "tls",
+          group: "security",
+        },
+        {
           name: "padding_scheme",
           type: "textarea",
           label: t("padding_scheme", "Padding Scheme"),
@@ -1108,12 +1119,14 @@ export function useProtocolFields() {
           type: "input",
           label: t("security_sni", "SNI"),
           group: "security",
+          condition: (p) => p.security !== "none",
         },
         {
           name: "allow_insecure",
           type: "switch",
           label: t("security_allow_insecure", "Allow Insecure"),
           group: "security",
+          condition: (p) => p.security !== "none",
         },
         {
           name: "fingerprint",
@@ -1122,6 +1135,7 @@ export function useProtocolFields() {
           options: FINGERPRINTS,
           defaultValue: "chrome",
           group: "security",
+          condition: (p) => p.security !== "none",
         },
         {
           name: "cert_mode",
@@ -1130,6 +1144,7 @@ export function useProtocolFields() {
           options: CERT_MODES,
           defaultValue: "none",
           group: "security",
+          condition: (p) => p.security === "tls",
         },
         {
           name: "cert_dns_provider",
@@ -1147,6 +1162,66 @@ export function useProtocolFields() {
             "CF_DNS_API_TOKEN=1234567890abcdefghijklmnopqrstuvwxyz\nALI_ACCESS_KEY_ID=your_access_key_id\nALI_ACCESS_KEY_SECRET=your_access_key_secret",
           group: "security",
           condition: (p) => p.cert_mode === "dns",
+        },
+        {
+          name: "reality_server_addr",
+          type: "input",
+          label: t("security_server_address", "Reality Server Address"),
+          placeholder: t(
+            "security_server_address_placeholder",
+            "e.g. 1.2.3.4 or domain"
+          ),
+          group: "reality",
+          condition: (p) => p.security === "reality",
+        },
+        {
+          name: "reality_server_port",
+          type: "number",
+          label: t("security_server_port", "Reality Server Port"),
+          min: 1,
+          max: 65_535,
+          placeholder: "1-65535",
+          group: "reality",
+          condition: (p) => p.security === "reality",
+        },
+        {
+          name: "reality_private_key",
+          type: "input",
+          label: t("security_private_key", "Reality Private Key"),
+          placeholder: t(
+            "security_private_key_placeholder",
+            "Enter private key"
+          ),
+          group: "reality",
+          generate: {
+            function: generateRealityKeyPair,
+            updateFields: {
+              reality_private_key: "privateKey",
+              reality_public_key: "publicKey",
+            } as Record<string, string>,
+          },
+          condition: (p) => p.security === "reality",
+        },
+        {
+          name: "reality_public_key",
+          type: "input",
+          label: t("security_public_key", "Reality Public Key"),
+          placeholder: t(
+            "security_public_key_placeholder",
+            "Enter public key"
+          ),
+          group: "reality",
+          condition: (p) => p.security === "reality",
+        },
+        {
+          name: "reality_short_id",
+          type: "input",
+          label: t("security_short_id", "Reality Short ID"),
+          group: "reality",
+          generate: {
+            function: generateRealityShortId,
+          },
+          condition: (p) => p.security === "reality",
         },
       ],
     }),


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

**feat: 为 anytls 协议添加 Reality 支持**

- `SECURITY.anytls` 枚举新增 `"reality"` 选项
- anytls Zod schema 补充 5 个 Reality 字段：
  `reality_server_addr` / `reality_server_port` /
  `reality_private_key` / `reality_public_key` / `reality_short_id`
- `getProtocolDefaultConfig` 中同步追加上述字段的 null 默认值
- 表单新增 Reality 字段分组，`reality_private_key` 支持一键生成密钥对
  并联动填充 `reality_public_key`（复用 `generateRealityKeyPair`）
- 将 `cert_mode` / `cert_dns_provider` / `cert_dns_env` 的可见条件从
  `security !== "none"` 收窄为 `security === "tls"`，
  避免在 Reality 模式下展示无关的证书申请字段

**fix: 修正 vless flow 配置项的枚举值与显示约束**

- 从 `FLOWS.vless` 中移除已废弃的 `xtls-rprx-direct` 与
  `xtls-rprx-splice`（xray-core v1.8+ 已移除）
- 收紧 flow 字段的显示条件：
  - `encryption === "mlkem768x25519plus"` 时，无视传输层直接显示
  - 否则需满足 `transport === "tcp"` 且 `security ∈ { tls, reality }`

#### 📝 补充信息 | Additional Information

anytls 的 Reality 实现与 vless 保持字段命名和生成逻辑完全一致，
便于后续统一维护。