### PR TITLE
docs(zh-CN): fix local dev cd directory to frontend

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,7 +68,7 @@
 
 ```bash
 git clone https://github.com/perfect-panel/frontend.git
-cd ppanel-web
+cd frontend
 
 # 安装依赖
 bun install


### PR DESCRIPTION
The Chinese README local development section said `cd ppanel-web` after cloning `perfect-panel/frontend.git`, which creates a `frontend` directory. This aligns README.zh-CN.md with README.md.