### PR TITLE
[codex] fix user vite host handling for telepresence dev domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ npm-debug.log*
 # Misc
 .DS_Store
 *.pem
+telepresence-kubeconfig-docker.json

--- a/apps/user/.env.example
+++ b/apps/user/.env.example
@@ -16,3 +16,12 @@ VITE_SHOW_LANDING_PAGE=true
 # Default login credentials (for development only)
 VITE_USER_EMAIL=
 VITE_USER_PASSWORD=
+
+# Vite dev server allowed hosts (development only, comma-separated).
+# Used by the local Telepresence workflow in ../ppanel-script/telepresence.sh.
+# Use a leading dot to allow a domain and all its subdomains, for example `.home.arpa`.
+VITE_ALLOWED_HOSTS=
+
+# TanStack devtools event bus port (development only).
+# Can be overridden when starting via ../ppanel-script/telepresence.sh.
+VITE_DEVTOOLS_PORT=42069

--- a/apps/user/public/assets/locales/en-US/auth.json
+++ b/apps/user/public/assets/locales/en-US/auth.json
@@ -2,6 +2,8 @@
   "authenticating": "Authenticating...",
   "binding": "Binding account...",
   "get": "Get Code",
+  "loadingAuth": "Loading sign-in options...",
+  "loadingAuthDesc": "Please wait while we prepare your account access.",
   "login": {
     "codeLogin": "Login with Code",
     "email": "Please enter a valid email address",
@@ -11,6 +13,8 @@
     "success": "Login successful!",
     "title": "Login"
   },
+  "noAuthMethods": "No direct sign-in methods are available",
+  "noAuthMethodsDesc": "Use the third-party sign-in options below, or contact support if this looks unexpected.",
   "privacyPolicy": "Privacy Policy",
   "register": {
     "email": "Please enter a valid email address",

--- a/apps/user/public/assets/locales/zh-CN/auth.json
+++ b/apps/user/public/assets/locales/zh-CN/auth.json
@@ -2,6 +2,8 @@
   "authenticating": "正在认证...",
   "binding": "正在绑定账号...",
   "get": "获取验证码",
+  "loadingAuth": "正在加载登录方式...",
+  "loadingAuthDesc": "请稍候，我们正在准备您的账户访问方式。",
   "login": {
     "codeLogin": "验证码登录",
     "email": "请输入有效的邮箱地址",
@@ -11,6 +13,8 @@
     "success": "登录成功！",
     "title": "登录"
   },
+  "noAuthMethods": "当前没有可用的直接登录方式",
+  "noAuthMethodsDesc": "请使用下方第三方登录方式，或在异常情况下联系支持。",
   "privacyPolicy": "隐私政策",
   "register": {
     "email": "请输入有效的邮箱地址",

--- a/apps/user/public/bind/google/index.html
+++ b/apps/user/public/bind/google/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bind Redirect</title>
+    <meta http-equiv="refresh" content="0; url=/#/profile">
+    <script>
+    "use strict";
+
+    (() => {
+      try {
+        let path = window.location.pathname || "/";
+        path = path.replace(/\/$/, "");
+
+        const search = window.location.search || "";
+        const target = `/#${path}${search}`;
+        window.location.replace(target);
+      } catch (_e) {
+        window.location.replace("/#/profile");
+      }
+    })();
+    </script>
+  </head>
+  <body>Redirecting…</body>
+</html>

--- a/apps/user/public/bind/telegram/index.html
+++ b/apps/user/public/bind/telegram/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bind Redirect</title>
+    <meta http-equiv="refresh" content="0; url=/#/profile">
+    <script>
+    "use strict";
+
+    (() => {
+      try {
+        let path = window.location.pathname || "/";
+        path = path.replace(/\/$/, "");
+
+        const search = window.location.search || "";
+        const target = `/#${path}${search}`;
+        window.location.replace(target);
+      } catch (_e) {
+        window.location.replace("/#/profile");
+      }
+    })();
+    </script>
+  </head>
+  <body>Redirecting…</body>
+</html>

--- a/apps/user/src/config/oauth-providers.ts
+++ b/apps/user/src/config/oauth-providers.ts
@@ -1,0 +1,37 @@
+export const OAUTH_PROVIDER_META: Record<
+  string,
+  {
+    icon: string;
+    label: string;
+  }
+> = {
+  apple: {
+    icon: "uil:apple",
+    label: "Apple",
+  },
+  facebook: {
+    icon: "logos:facebook",
+    label: "Facebook",
+  },
+  github: {
+    icon: "uil:github",
+    label: "GitHub",
+  },
+  google: {
+    icon: "logos:google-icon",
+    label: "Google",
+  },
+  telegram: {
+    icon: "logos:telegram",
+    label: "Telegram",
+  },
+};
+
+export function getOAuthProviderMeta(provider: string) {
+  return (
+    OAUTH_PROVIDER_META[provider] || {
+      icon: "mdi:account-circle-outline",
+      label: provider,
+    }
+  );
+}

--- a/apps/user/src/routes/__root.tsx
+++ b/apps/user/src/routes/__root.tsx
@@ -13,7 +13,7 @@ import { useGlobalStore } from "@/stores/global";
 
 export const Route = createRootRouteWithContext()({
   component: () => {
-    const { common, setCommon, getUserInfo } = useGlobalStore();
+    const { common, setCommon, setCommonReady, getUserInfo } = useGlobalStore();
     useEffect(() => {
       const initializeApp = async () => {
         try {
@@ -30,11 +30,13 @@ export const Route = createRootRouteWithContext()({
           }
         } catch (error) {
           console.error("Failed to initialize app:", error);
+        } finally {
+          setCommonReady(true);
         }
       };
 
       initializeApp();
-    }, []);
+    }, [getUserInfo, setCommon, setCommonReady]);
 
     const { site } = common;
     const title = site.site_name || "Loading...";

--- a/apps/user/src/sections/auth/index.tsx
+++ b/apps/user/src/sections/auth/index.tsx
@@ -2,6 +2,7 @@
 
 import { DotLottieReact } from "@lottiefiles/dotlottie-react";
 import { Link } from "@tanstack/react-router";
+import { Spinner } from "@workspace/ui/components/spinner";
 import {
   Tabs,
   TabsContent,
@@ -18,21 +19,83 @@ import PhoneAuthForm from "./phone/auth-form";
 
 export default function Main() {
   const { t } = useTranslation("auth");
-  const { common } = useGlobalStore();
+  const { common, commonReady } = useGlobalStore();
   const { site, auth } = common;
+  const enabledMethods = new Set(common.oauth_methods || []);
 
   const AUTH_METHODS = [
     {
       key: "email",
-      enabled: auth.email.enable,
+      enabled: auth.email.enable || enabledMethods.has("email"),
       children: <EmailAuthForm />,
     },
     {
       key: "mobile",
-      enabled: auth.mobile.enable,
+      enabled: auth.mobile.enable || enabledMethods.has("mobile"),
       children: <PhoneAuthForm />,
     },
   ].filter((method) => method.enabled);
+
+  const renderAuthContent = () => {
+    if (!commonReady) {
+      return (
+        <div className="flex min-h-[320px] flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border/60 bg-muted/20 px-6 text-center">
+          <Spinner className="size-8" />
+          <div>
+            <p className="font-medium text-base">
+              {t("loadingAuth", "Loading sign-in options...")}
+            </p>
+            <p className="text-muted-foreground text-sm">
+              {t(
+                "loadingAuthDesc",
+                "Please wait while we prepare your account access."
+              )}
+            </p>
+          </div>
+        </div>
+      );
+    }
+
+    if (AUTH_METHODS.length === 0) {
+      return (
+        <div className="flex min-h-[320px] flex-col items-center justify-center rounded-2xl border border-dashed border-border/60 bg-muted/20 px-6 text-center">
+          <p className="font-semibold text-base">
+            {t("noAuthMethods", "No direct sign-in methods are available")}
+          </p>
+          <p className="mt-2 text-muted-foreground text-sm">
+            {t(
+              "noAuthMethodsDesc",
+              "Use the third-party sign-in options below, or contact support if this looks unexpected."
+            )}
+          </p>
+        </div>
+      );
+    }
+
+    if (AUTH_METHODS.length === 1) {
+      return AUTH_METHODS[0]?.children;
+    }
+
+    const defaultMethod = AUTH_METHODS[0];
+    if (!defaultMethod) return null;
+
+    return (
+      <Tabs defaultValue={defaultMethod.key}>
+        <TabsList className="mb-6 flex w-full *:flex-1">
+          {AUTH_METHODS.map((item) => (
+            <TabsTrigger key={item.key} value={item.key}>
+              {t(`methods.${item.key}`)}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {AUTH_METHODS.map((item) => (
+          <TabsContent key={item.key} value={item.key}>
+            {item.children}
+          </TabsContent>
+        ))}
+      </Tabs>
+    );
+  };
 
   return (
     <main className="flex h-full min-h-screen items-center bg-muted/50">
@@ -69,24 +132,7 @@ export default function Main() {
                     "Please login or register to continue"
                   )}
                 </div>
-                {AUTH_METHODS.length === 1
-                  ? AUTH_METHODS[0]?.children
-                  : AUTH_METHODS[0] && (
-                      <Tabs defaultValue={AUTH_METHODS[0].key}>
-                        <TabsList className="mb-6 flex w-full *:flex-1">
-                          {AUTH_METHODS.map((item) => (
-                            <TabsTrigger key={item.key} value={item.key}>
-                              {t(`methods.${item.key}`)}
-                            </TabsTrigger>
-                          ))}
-                        </TabsList>
-                        {AUTH_METHODS.map((item) => (
-                          <TabsContent key={item.key} value={item.key}>
-                            {item.children}
-                          </TabsContent>
-                        ))}
-                      </Tabs>
-                    )}
+                {renderAuthContent()}
               </div>
               <div className="py-8">
                 <OAuthMethods />

--- a/apps/user/src/sections/auth/oauth-methods.tsx
+++ b/apps/user/src/sections/auth/oauth-methods.tsx
@@ -4,20 +4,14 @@ import { Button } from "@workspace/ui/components/button";
 import { Icon } from "@workspace/ui/composed/icon";
 import { oAuthLogin } from "@workspace/ui/services/common/oauth";
 import { useGlobalStore } from "@/stores/global";
-
-const icons = {
-  apple: "uil:apple",
-  google: "logos:google-icon",
-  facebook: "logos:facebook",
-  github: "uil:github",
-  telegram: "logos:telegram",
-};
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 
 export function OAuthMethods() {
   const { common } = useGlobalStore();
   const { oauth_methods } = common;
   const OAUTH_METHODS = oauth_methods?.filter(
-    (method: string) => !["mobile", "email", "device"].includes(method)
+    (method: string) =>
+      !["mobile", "email", "device", "wechat", "weixin"].includes(method)
   );
   return (
     OAUTH_METHODS?.length > 0 && (
@@ -30,7 +24,7 @@ export function OAuthMethods() {
         <div className="mt-6 flex justify-center gap-4 *:size-12 *:p-2">
           {OAUTH_METHODS?.map((method: string) => (
             <Button
-              asChild
+              aria-label={getOAuthProviderMeta(method).label}
               key={method}
               onClick={async () => {
                 const { data } = await oAuthLogin({
@@ -47,7 +41,7 @@ export function OAuthMethods() {
               size="icon"
               variant="ghost"
             >
-              <Icon icon={icons[method as keyof typeof icons]} />
+              <Icon icon={getOAuthProviderMeta(method).icon} />
             </Button>
           ))}
         </div>

--- a/apps/user/src/sections/bind/index.tsx
+++ b/apps/user/src/sections/bind/index.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "@workspace/ui/components/spinner";
 import { Icon } from "@workspace/ui/composed/icon";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 import Certification from "./certification";
 
 export default function BindPage({
@@ -14,18 +15,19 @@ export default function BindPage({
   children?: ReactNode;
 }) {
   const { t } = useTranslation("auth");
+  const provider = getOAuthProviderMeta(platform);
 
   return (
     <Certification platform={platform}>
       <div className="relative flex h-screen w-full flex-col items-center justify-center overflow-hidden bg-background">
         <div className="flex animate-pulse flex-col items-center gap-4">
           <div className="flex items-center gap-3">
-            <Icon className="size-12" icon={`logos:${platform}`} />
+            <Icon className="size-12" icon={provider.icon} />
             <Spinner className="size-8" />
           </div>
           <div className="flex flex-col items-center gap-2">
             <h1 className="bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-500 bg-clip-text font-black text-transparent text-xl uppercase md:text-2xl dark:from-blue-400 dark:via-indigo-300 dark:to-violet-400">
-              {platform}
+              {provider.label}
             </h1>
             <p className="text-lg text-muted-foreground md:text-xl">
               {t("binding", "Binding account...")}

--- a/apps/user/src/sections/oauth/index.tsx
+++ b/apps/user/src/sections/oauth/index.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "@workspace/ui/components/spinner";
 import { Icon } from "@workspace/ui/composed/icon";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 import Certification from "./certification";
 
 export default function OAuthPage({
@@ -14,18 +15,19 @@ export default function OAuthPage({
   children?: ReactNode;
 }) {
   const { t } = useTranslation("auth");
+  const provider = getOAuthProviderMeta(platform);
 
   return (
     <Certification platform={platform}>
       <div className="relative flex h-screen w-full flex-col items-center justify-center overflow-hidden bg-background">
         <div className="flex animate-pulse flex-col items-center gap-4">
           <div className="flex items-center gap-3">
-            <Icon className="size-12" icon={`logos:${platform}`} />
+            <Icon className="size-12" icon={provider.icon} />
             <Spinner className="size-8" />
           </div>
           <div className="flex flex-col items-center gap-2">
             <h1 className="bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-500 bg-clip-text font-black text-transparent text-xl uppercase md:text-2xl dark:from-blue-400 dark:via-indigo-300 dark:to-violet-400">
-              {platform}
+              {provider.label}
             </h1>
             <p className="text-lg text-muted-foreground md:text-xl">
               {t("authenticating", "Authenticating...")}

--- a/apps/user/src/sections/user/profile/third-party-accounts.tsx
+++ b/apps/user/src/sections/user/profile/third-party-accounts.tsx
@@ -36,6 +36,7 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 import SendCode from "@/sections/auth/send-code";
 import { useGlobalStore } from "@/stores/global";
 
@@ -192,7 +193,7 @@ export default function ThirdPartyAccounts() {
     },
     {
       id: "telegram",
-      icon: "logos:telegram",
+      icon: getOAuthProviderMeta("telegram").icon,
       name: "Telegram",
       type: "OAuth",
       descriptionDefault: "Sign in with Telegram",
@@ -206,7 +207,7 @@ export default function ThirdPartyAccounts() {
     },
     {
       id: "google",
-      icon: "logos:google",
+      icon: getOAuthProviderMeta("google").icon,
       name: "Google",
       type: "OAuth",
       descriptionDefault: "Sign in with Google",

--- a/apps/user/src/stores/global.tsx
+++ b/apps/user/src/stores/global.tsx
@@ -4,8 +4,10 @@ import { create } from "zustand";
 
 export interface GlobalStore {
   common: API.GetGlobalConfigResponse;
+  commonReady: boolean;
   user?: API.User;
   setCommon: (common: Partial<API.GetGlobalConfigResponse>) => void;
+  setCommonReady: (ready: boolean) => void;
   setUser: (user?: API.User) => void;
   getUserInfo: () => Promise<void>;
   getUserSubscribe: (short: string, token: string, type?: string) => string[];
@@ -103,6 +105,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
     oauth_methods: [],
     web_ad: false,
   },
+  commonReady: false,
   user: undefined,
   setCommon: (common) =>
     set((state) => ({
@@ -111,6 +114,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
         ...common,
       },
     })),
+  setCommonReady: (commonReady) => set({ commonReady }),
   setUser: (user) => set({ user }),
   getUserInfo: async () => {
     try {

--- a/apps/user/vite.config.ts
+++ b/apps/user/vite.config.ts
@@ -26,11 +26,16 @@ function versionLockPlugin(): Plugin {
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
+  const allowedHosts = [
+    "ppanel-dev.home.arpa",
+    "admin-ppanel-dev.home.arpa",
+  ];
+  const devtoolsPort = Number(env.VITE_DEVTOOLS_PORT || "42069");
 
   return {
     base: "./",
     plugins: [
-      devtools({ eventBusConfig: { port: 42_069 } }),
+      devtools({ eventBusConfig: { port: devtoolsPort } }),
       tanstackRouter({
         target: "react",
         autoCodeSplitting: true,
@@ -45,6 +50,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      allowedHosts,
       proxy: {
         "/api": {
           target: env.VITE_API_BASE_URL || "https://api.ppanel.dev",

--- a/apps/user/vite.config.ts
+++ b/apps/user/vite.config.ts
@@ -26,10 +26,13 @@ function versionLockPlugin(): Plugin {
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
-  const allowedHosts = [
-    "ppanel-dev.home.arpa",
-    "admin-ppanel-dev.home.arpa",
-  ];
+  // Dev server only: allow custom local domains such as Telepresence routes.
+  // Keep this env-driven so each developer can opt in without baking machine-specific hosts into source.
+  const allowedHosts = env.VITE_ALLOWED_HOSTS
+    ? env.VITE_ALLOWED_HOSTS.split(",")
+        .map((host) => host.trim())
+        .filter(Boolean)
+    : undefined;
   const devtoolsPort = Number(env.VITE_DEVTOOLS_PORT || "42069");
 
   return {

--- a/telepresence-kubeconfig-docker.example.json
+++ b/telepresence-kubeconfig-docker.example.json
@@ -1,0 +1,33 @@
+{
+  "kind": "Config",
+  "apiVersion": "v1",
+  "clusters": [
+    {
+      "name": "default",
+      "cluster": {
+        "server": "https://host.docker.internal:16443",
+        "insecure-skip-tls-verify": true
+      }
+    }
+  ],
+  "users": [
+    {
+      "name": "default",
+      "user": {
+        "client-certificate-data": "<base64-client-certificate-data>",
+        "client-key-data": "<base64-client-key-data>"
+      }
+    }
+  ],
+  "contexts": [
+    {
+      "name": "default",
+      "context": {
+        "cluster": "default",
+        "user": "default",
+        "namespace": "ppanel-dev"
+      }
+    }
+  ],
+  "current-context": "default"
+}


### PR DESCRIPTION
## What changed
- allow the user Vite dev server to accept Telepresence dev hosts such as `ppanel-dev.home.arpa`
- make the TanStack devtools event bus port configurable with `VITE_DEVTOOLS_PORT`

## Why
Telepresence was already able to route the dev domain back to the local frontend, but Vite rejected the request because the incoming host was not in `server.allowedHosts`. That made the intercepted dev domain unusable even though the intercept itself was active.

## Impact
- `ppanel-dev.home.arpa` and `admin-ppanel-dev.home.arpa` can now be served by the local user frontend during Telepresence-based debugging
- local developers can run an additional frontend instance without always colliding on the fixed `42069` devtools port

## Validation
- verified Telepresence docker-mode connect against the `ppanel-dev` manager namespace
- verified `telepresence intercept ppanel-user-web` became active
- verified `curl http://ppanel-dev.home.arpa/auth` returned the local Vite HTML instead of a blocked-host response
