### PR TITLE
[codex] fix admin auth form click handling over login animation

### DIFF
--- a/.github/workflows/ghcr-images.yml
+++ b/.github/workflows/ghcr-images.yml
@@ -1,0 +1,126 @@
+name: Publish GHCR Images
+
+on:
+  push:
+    branches: [main, next, beta, develop]
+    tags:
+      - "v*"
+    paths-ignore:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-assets:
+    name: Build Frontend Assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install deps
+        run: bun install
+
+      - name: Build admin and user apps
+        run: bun run build
+
+      - name: Archive admin dist
+        run: tar -czf ppanel-admin-web-dist.tar.gz -C apps/admin dist
+
+      - name: Archive user dist
+        run: tar -czf ppanel-user-web-dist.tar.gz -C apps/user dist
+
+      - name: Upload admin dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: ppanel-admin-web-dist
+          path: ppanel-admin-web-dist.tar.gz
+          if-no-files-found: error
+
+      - name: Upload user dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: ppanel-user-web-dist
+          path: ppanel-user-web-dist.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    needs: build-assets
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ppanel-admin-web
+            artifact: ppanel-admin-web-dist
+            tarball: ppanel-admin-web-dist.tar.gz
+            extract_path: apps/admin
+            dockerfile: docker/ppanel-admin-web/Dockerfile
+          - image: ppanel-user-web
+            artifact: ppanel-user-web-dist
+            tarball: ppanel-user-web-dist.tar.gz
+            extract_path: apps/user
+            dockerfile: docker/ppanel-user-web/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: .
+
+      - name: Extract build artifact
+        run: tar -xzf ${{ matrix.tarball }} -C ${{ matrix.extract_path }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/apps/admin/src/sections/auth/index.tsx
+++ b/apps/admin/src/sections/auth/index.tsx
@@ -20,9 +20,9 @@ export default function Auth() {
   }, [navigate, user]);
 
   return (
-    <main className="flex h-full min-h-screen items-center bg-muted/50">
+    <main className="flex h-full min-h-screen items-center bg-muted/50 [&_canvas]:pointer-events-none">
       <div className="flex size-full flex-auto flex-col justify-center lg:flex-row">
-        <div className="flex lg:w-1/2 lg:flex-auto">
+        <div className="flex lg:pointer-events-none lg:w-1/2 lg:flex-auto">
           <div className="flex w-full flex-col items-center justify-center px-5 py-4 md:px-14 lg:py-14">
             <Link className="mb-0 flex flex-col items-center lg:mb-12" to="/">
               <img
@@ -35,7 +35,7 @@ export default function Auth() {
             </Link>
             <DotLottieReact
               autoplay
-              className="mx-auto hidden w-full lg:block"
+              className="pointer-events-none mx-auto hidden w-full lg:block"
               loop
               src="./assets/lotties/login.json"
             />
@@ -44,8 +44,8 @@ export default function Auth() {
             </p>
           </div>
         </div>
-        <div className="flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
-          <div className="flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
+        <div className="relative z-10 flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
+          <div className="relative z-10 flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
             <div className="flex flex-col items-stretch justify-center md:w-[400px] lg:h-full">
               <div className="flex flex-col justify-center pb-14 lg:flex-auto lg:pb-20">
                 <EmailAuthForm />

--- a/docker/ppanel-admin-web/Dockerfile
+++ b/docker/ppanel-admin-web/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27-alpine
+
+COPY apps/admin/dist /usr/share/nginx/html

--- a/docker/ppanel-user-web/Dockerfile
+++ b/docker/ppanel-user-web/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27-alpine
+
+COPY apps/user/dist /usr/share/nginx/html


### PR DESCRIPTION
## What changed
- prevent the decorative login animation pane from capturing pointer events on the admin auth page
- raise the auth form container above the background media so the form stays clickable

## Why
On large screens, the left-side lottie/canvas layer could sit above the interactive auth card and make the login form feel blank or unresponsive.

## Impact
Admins can reliably interact with the login form without the background animation blocking clicks.

## Validation
- `npx biome check apps/admin/src/sections/auth/index.tsx`
