### PR TITLE
[codex] use deployed web version for dashboard badge

### DIFF
--- a/.github/workflows/ghcr-images.yml
+++ b/.github/workflows/ghcr-images.yml
@@ -1,0 +1,126 @@
+name: Publish GHCR Images
+
+on:
+  push:
+    branches: [main, next, beta, develop]
+    tags:
+      - "v*"
+    paths-ignore:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-assets:
+    name: Build Frontend Assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install deps
+        run: bun install
+
+      - name: Build admin and user apps
+        run: bun run build
+
+      - name: Archive admin dist
+        run: tar -czf ppanel-admin-web-dist.tar.gz -C apps/admin dist
+
+      - name: Archive user dist
+        run: tar -czf ppanel-user-web-dist.tar.gz -C apps/user dist
+
+      - name: Upload admin dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: ppanel-admin-web-dist
+          path: ppanel-admin-web-dist.tar.gz
+          if-no-files-found: error
+
+      - name: Upload user dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: ppanel-user-web-dist
+          path: ppanel-user-web-dist.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    needs: build-assets
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ppanel-admin-web
+            artifact: ppanel-admin-web-dist
+            tarball: ppanel-admin-web-dist.tar.gz
+            extract_path: apps/admin
+            dockerfile: docker/ppanel-admin-web/Dockerfile
+          - image: ppanel-user-web
+            artifact: ppanel-user-web-dist
+            tarball: ppanel-user-web-dist.tar.gz
+            extract_path: apps/user
+            dockerfile: docker/ppanel-user-web/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: .
+
+      - name: Extract build artifact
+        run: tar -xzf ${{ matrix.tarball }} -C ${{ matrix.extract_path }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ npm-debug.log*
 # Misc
 .DS_Store
 *.pem
+telepresence-kubeconfig-docker.json

--- a/apps/admin/src/sections/auth/index.tsx
+++ b/apps/admin/src/sections/auth/index.tsx
@@ -20,9 +20,9 @@ export default function Auth() {
   }, [navigate, user]);
 
   return (
-    <main className="flex h-full min-h-screen items-center bg-muted/50">
+    <main className="flex h-full min-h-screen items-center bg-muted/50 [&_canvas]:pointer-events-none">
       <div className="flex size-full flex-auto flex-col justify-center lg:flex-row">
-        <div className="flex lg:w-1/2 lg:flex-auto">
+        <div className="flex lg:pointer-events-none lg:w-1/2 lg:flex-auto">
           <div className="flex w-full flex-col items-center justify-center px-5 py-4 md:px-14 lg:py-14">
             <Link className="mb-0 flex flex-col items-center lg:mb-12" to="/">
               <img
@@ -35,7 +35,7 @@ export default function Auth() {
             </Link>
             <DotLottieReact
               autoplay
-              className="mx-auto hidden w-full lg:block"
+              className="pointer-events-none mx-auto hidden w-full lg:block"
               loop
               src="./assets/lotties/login.json"
             />
@@ -44,8 +44,8 @@ export default function Auth() {
             </p>
           </div>
         </div>
-        <div className="flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
-          <div className="flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
+        <div className="relative z-10 flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
+          <div className="relative z-10 flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
             <div className="flex flex-col items-stretch justify-center md:w-[400px] lg:h-full">
               <div className="flex flex-col justify-center pb-14 lg:flex-auto lg:pb-20">
                 <EmailAuthForm />

--- a/apps/admin/src/sections/auth/index.tsx
+++ b/apps/admin/src/sections/auth/index.tsx
@@ -20,9 +20,9 @@ export default function Auth() {
   }, [navigate, user]);
 
   return (
-    <main className="flex h-full min-h-screen items-center bg-muted/50">
+    <main className="flex h-full min-h-screen items-center bg-muted/50 [&_canvas]:pointer-events-none">
       <div className="flex size-full flex-auto flex-col justify-center lg:flex-row">
-        <div className="flex lg:w-1/2 lg:flex-auto">
+        <div className="flex lg:w-1/2 lg:flex-auto lg:pointer-events-none">
           <div className="flex w-full flex-col items-center justify-center px-5 py-4 md:px-14 lg:py-14">
             <Link className="mb-0 flex flex-col items-center lg:mb-12" to="/">
               <img
@@ -35,7 +35,7 @@ export default function Auth() {
             </Link>
             <DotLottieReact
               autoplay
-              className="mx-auto hidden w-full lg:block"
+              className="pointer-events-none mx-auto hidden w-full lg:block"
               loop
               src="./assets/lotties/login.json"
             />
@@ -44,8 +44,8 @@ export default function Auth() {
             </p>
           </div>
         </div>
-        <div className="flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
-          <div className="flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
+        <div className="relative z-10 flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
+          <div className="relative z-10 flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
             <div className="flex flex-col items-stretch justify-center md:w-[400px] lg:h-full">
               <div className="flex flex-col justify-center pb-14 lg:flex-auto lg:pb-20">
                 <EmailAuthForm />

--- a/apps/admin/src/sections/auth/index.tsx
+++ b/apps/admin/src/sections/auth/index.tsx
@@ -21,7 +21,7 @@ export default function Auth() {
 
   return (
     <main className="flex h-full min-h-screen items-center bg-muted/50 [&_canvas]:pointer-events-none">
-        <div className="flex size-full flex-auto flex-col justify-center lg:flex-row">
+      <div className="flex size-full flex-auto flex-col justify-center lg:flex-row">
         <div className="flex lg:pointer-events-none lg:w-1/2 lg:flex-auto">
           <div className="flex w-full flex-col items-center justify-center px-5 py-4 md:px-14 lg:py-14">
             <Link className="mb-0 flex flex-col items-center lg:mb-12" to="/">

--- a/apps/admin/src/sections/dashboard/components/system-version-card.tsx
+++ b/apps/admin/src/sections/dashboard/components/system-version-card.tsx
@@ -27,7 +27,18 @@ import { basicUpdateService } from "@workspace/ui/services/gateway/basicUpdateSe
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import packageJson from "../../../../../../package.json";
+
+async function getDeployedWebVersion() {
+  const response = await fetch(new URL("version.lock", window.location.href), {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load version.lock: ${response.status}`);
+  }
+
+  return (await response.text()).trim();
+}
 
 export default function SystemVersionCard() {
   const { t } = useTranslation("tool");
@@ -81,6 +92,13 @@ export default function SystemVersionCard() {
     retry: 1,
   });
 
+  const { data: deployedWebVersion } = useQuery({
+    queryKey: ["deployedWebVersion"],
+    queryFn: getDeployedWebVersion,
+    staleTime: 0,
+    retry: 1,
+  });
+
   const updateServerMutation = useMutation({
     mutationFn: async (serviceName: string) => {
       await basicUpdateService({
@@ -128,6 +146,8 @@ export default function SystemVersionCard() {
   const hasServerNewVersion = serverVersionInfo?.has_update ?? false;
   const hasWebNewVersion = webVersionInfo?.has_update ?? false;
   const isUpdatingServer = updateServerMutation.isPending;
+  const currentWebVersion =
+    deployedWebVersion || webVersionInfo?.current_version || "-";
 
   return (
     <Card className="gap-0 p-3">
@@ -187,7 +207,7 @@ export default function SystemVersionCard() {
             </span>
           </div>
           <div className="flex items-center space-x-2">
-            <Badge>V{packageJson.version}</Badge>
+            <Badge>V{currentWebVersion}</Badge>
             <AlertDialog onOpenChange={setOpenUpdateWeb} open={openUpdateWeb}>
               <AlertDialogTrigger asChild>
                 <Button

--- a/apps/admin/src/stores/global.tsx
+++ b/apps/admin/src/stores/global.tsx
@@ -114,7 +114,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
   setUser: (user) => set({ user }),
   getUserInfo: async () => {
     try {
-      const { data } = await currentUser();
+      const { data } = await currentUser({ skipErrorHandler: true });
       set({ user: data.data });
     } catch (error) {
       console.error("Failed to refresh user:", error);

--- a/apps/user/.env.example
+++ b/apps/user/.env.example
@@ -16,3 +16,12 @@ VITE_SHOW_LANDING_PAGE=true
 # Default login credentials (for development only)
 VITE_USER_EMAIL=
 VITE_USER_PASSWORD=
+
+# Vite dev server allowed hosts (development only, comma-separated).
+# Used by the local Telepresence workflow in ../ppanel-script/telepresence.sh.
+# Use a leading dot to allow a domain and all its subdomains, for example `.home.arpa`.
+VITE_ALLOWED_HOSTS=
+
+# TanStack devtools event bus port (development only).
+# Can be overridden when starting via ../ppanel-script/telepresence.sh.
+VITE_DEVTOOLS_PORT=42069

--- a/apps/user/.env.production
+++ b/apps/user/.env.production
@@ -1,2 +1,4 @@
+# Use same-origin requests in production; ingress handles /api -> backend routing.
+VITE_API_BASE_URL=
 # Route browser API requests through the ingress rewrite in production.
 VITE_API_PREFIX=/api

--- a/apps/user/.env.production
+++ b/apps/user/.env.production
@@ -1,0 +1,2 @@
+# Route browser API requests through the ingress rewrite in production.
+VITE_API_PREFIX=/api

--- a/apps/user/public/assets/locales/en-US/auth.json
+++ b/apps/user/public/assets/locales/en-US/auth.json
@@ -2,6 +2,8 @@
   "authenticating": "Authenticating...",
   "binding": "Binding account...",
   "get": "Get Code",
+  "loadingAuth": "Loading sign-in options...",
+  "loadingAuthDesc": "Please wait while we prepare your account access.",
   "login": {
     "codeLogin": "Login with Code",
     "email": "Please enter a valid email address",
@@ -11,6 +13,8 @@
     "success": "Login successful!",
     "title": "Login"
   },
+  "noAuthMethods": "No direct sign-in methods are available",
+  "noAuthMethodsDesc": "Use the third-party sign-in options below, or contact support if this looks unexpected.",
   "privacyPolicy": "Privacy Policy",
   "register": {
     "email": "Please enter a valid email address",

--- a/apps/user/public/assets/locales/zh-CN/auth.json
+++ b/apps/user/public/assets/locales/zh-CN/auth.json
@@ -2,6 +2,8 @@
   "authenticating": "正在认证...",
   "binding": "正在绑定账号...",
   "get": "获取验证码",
+  "loadingAuth": "正在加载登录方式...",
+  "loadingAuthDesc": "请稍候，我们正在准备您的账户访问方式。",
   "login": {
     "codeLogin": "验证码登录",
     "email": "请输入有效的邮箱地址",
@@ -11,6 +13,8 @@
     "success": "登录成功！",
     "title": "登录"
   },
+  "noAuthMethods": "当前没有可用的直接登录方式",
+  "noAuthMethodsDesc": "请使用下方第三方登录方式，或在异常情况下联系支持。",
   "privacyPolicy": "隐私政策",
   "register": {
     "email": "请输入有效的邮箱地址",

--- a/apps/user/public/bind/google/index.html
+++ b/apps/user/public/bind/google/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bind Redirect</title>
+    <meta http-equiv="refresh" content="0; url=/#/profile">
+    <script>
+    "use strict";
+
+    (() => {
+      try {
+        let path = window.location.pathname || "/";
+        path = path.replace(/\/$/, "");
+
+        const search = window.location.search || "";
+        const target = `/#${path}${search}`;
+        window.location.replace(target);
+      } catch (_e) {
+        window.location.replace("/#/profile");
+      }
+    })();
+    </script>
+  </head>
+  <body>Redirecting…</body>
+</html>

--- a/apps/user/public/bind/telegram/index.html
+++ b/apps/user/public/bind/telegram/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bind Redirect</title>
+    <meta http-equiv="refresh" content="0; url=/#/profile">
+    <script>
+    "use strict";
+
+    (() => {
+      try {
+        let path = window.location.pathname || "/";
+        path = path.replace(/\/$/, "");
+
+        const search = window.location.search || "";
+        const target = `/#${path}${search}`;
+        window.location.replace(target);
+      } catch (_e) {
+        window.location.replace("/#/profile");
+      }
+    })();
+    </script>
+  </head>
+  <body>Redirecting…</body>
+</html>

--- a/apps/user/src/config/oauth-providers.ts
+++ b/apps/user/src/config/oauth-providers.ts
@@ -1,0 +1,37 @@
+export const OAUTH_PROVIDER_META: Record<
+  string,
+  {
+    icon: string;
+    label: string;
+  }
+> = {
+  apple: {
+    icon: "uil:apple",
+    label: "Apple",
+  },
+  facebook: {
+    icon: "logos:facebook",
+    label: "Facebook",
+  },
+  github: {
+    icon: "uil:github",
+    label: "GitHub",
+  },
+  google: {
+    icon: "logos:google-icon",
+    label: "Google",
+  },
+  telegram: {
+    icon: "logos:telegram",
+    label: "Telegram",
+  },
+};
+
+export function getOAuthProviderMeta(provider: string) {
+  return (
+    OAUTH_PROVIDER_META[provider] || {
+      icon: "mdi:account-circle-outline",
+      label: provider,
+    }
+  );
+}

--- a/apps/user/src/routes/__root.tsx
+++ b/apps/user/src/routes/__root.tsx
@@ -13,7 +13,7 @@ import { useGlobalStore } from "@/stores/global";
 
 export const Route = createRootRouteWithContext()({
   component: () => {
-    const { common, setCommon, getUserInfo } = useGlobalStore();
+    const { common, setCommon, setCommonReady, getUserInfo } = useGlobalStore();
     useEffect(() => {
       const initializeApp = async () => {
         try {
@@ -30,11 +30,13 @@ export const Route = createRootRouteWithContext()({
           }
         } catch (error) {
           console.error("Failed to initialize app:", error);
+        } finally {
+          setCommonReady(true);
         }
       };
 
       initializeApp();
-    }, []);
+    }, [getUserInfo, setCommon, setCommonReady]);
 
     const { site } = common;
     const title = site.site_name || "Loading...";

--- a/apps/user/src/sections/auth/index.tsx
+++ b/apps/user/src/sections/auth/index.tsx
@@ -2,6 +2,7 @@
 
 import { DotLottieReact } from "@lottiefiles/dotlottie-react";
 import { Link } from "@tanstack/react-router";
+import { Spinner } from "@workspace/ui/components/spinner";
 import {
   Tabs,
   TabsContent,
@@ -18,21 +19,83 @@ import PhoneAuthForm from "./phone/auth-form";
 
 export default function Main() {
   const { t } = useTranslation("auth");
-  const { common } = useGlobalStore();
+  const { common, commonReady } = useGlobalStore();
   const { site, auth } = common;
+  const enabledMethods = new Set(common.oauth_methods || []);
 
   const AUTH_METHODS = [
     {
       key: "email",
-      enabled: auth.email.enable,
+      enabled: auth.email.enable || enabledMethods.has("email"),
       children: <EmailAuthForm />,
     },
     {
       key: "mobile",
-      enabled: auth.mobile.enable,
+      enabled: auth.mobile.enable || enabledMethods.has("mobile"),
       children: <PhoneAuthForm />,
     },
   ].filter((method) => method.enabled);
+
+  const renderAuthContent = () => {
+    if (!commonReady) {
+      return (
+        <div className="flex min-h-[320px] flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border/60 bg-muted/20 px-6 text-center">
+          <Spinner className="size-8" />
+          <div>
+            <p className="font-medium text-base">
+              {t("loadingAuth", "Loading sign-in options...")}
+            </p>
+            <p className="text-muted-foreground text-sm">
+              {t(
+                "loadingAuthDesc",
+                "Please wait while we prepare your account access."
+              )}
+            </p>
+          </div>
+        </div>
+      );
+    }
+
+    if (AUTH_METHODS.length === 0) {
+      return (
+        <div className="flex min-h-[320px] flex-col items-center justify-center rounded-2xl border border-dashed border-border/60 bg-muted/20 px-6 text-center">
+          <p className="font-semibold text-base">
+            {t("noAuthMethods", "No direct sign-in methods are available")}
+          </p>
+          <p className="mt-2 text-muted-foreground text-sm">
+            {t(
+              "noAuthMethodsDesc",
+              "Use the third-party sign-in options below, or contact support if this looks unexpected."
+            )}
+          </p>
+        </div>
+      );
+    }
+
+    if (AUTH_METHODS.length === 1) {
+      return AUTH_METHODS[0]?.children;
+    }
+
+    const defaultMethod = AUTH_METHODS[0];
+    if (!defaultMethod) return null;
+
+    return (
+      <Tabs defaultValue={defaultMethod.key}>
+        <TabsList className="mb-6 flex w-full *:flex-1">
+          {AUTH_METHODS.map((item) => (
+            <TabsTrigger key={item.key} value={item.key}>
+              {t(`methods.${item.key}`)}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {AUTH_METHODS.map((item) => (
+          <TabsContent key={item.key} value={item.key}>
+            {item.children}
+          </TabsContent>
+        ))}
+      </Tabs>
+    );
+  };
 
   return (
     <main className="flex h-full min-h-screen items-center bg-muted/50">
@@ -69,24 +132,7 @@ export default function Main() {
                     "Please login or register to continue"
                   )}
                 </div>
-                {AUTH_METHODS.length === 1
-                  ? AUTH_METHODS[0]?.children
-                  : AUTH_METHODS[0] && (
-                      <Tabs defaultValue={AUTH_METHODS[0].key}>
-                        <TabsList className="mb-6 flex w-full *:flex-1">
-                          {AUTH_METHODS.map((item) => (
-                            <TabsTrigger key={item.key} value={item.key}>
-                              {t(`methods.${item.key}`)}
-                            </TabsTrigger>
-                          ))}
-                        </TabsList>
-                        {AUTH_METHODS.map((item) => (
-                          <TabsContent key={item.key} value={item.key}>
-                            {item.children}
-                          </TabsContent>
-                        ))}
-                      </Tabs>
-                    )}
+                {renderAuthContent()}
               </div>
               <div className="py-8">
                 <OAuthMethods />

--- a/apps/user/src/sections/auth/oauth-methods.tsx
+++ b/apps/user/src/sections/auth/oauth-methods.tsx
@@ -4,20 +4,14 @@ import { Button } from "@workspace/ui/components/button";
 import { Icon } from "@workspace/ui/composed/icon";
 import { oAuthLogin } from "@workspace/ui/services/common/oauth";
 import { useGlobalStore } from "@/stores/global";
-
-const icons = {
-  apple: "uil:apple",
-  google: "logos:google-icon",
-  facebook: "logos:facebook",
-  github: "uil:github",
-  telegram: "logos:telegram",
-};
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 
 export function OAuthMethods() {
   const { common } = useGlobalStore();
   const { oauth_methods } = common;
   const OAUTH_METHODS = oauth_methods?.filter(
-    (method: string) => !["mobile", "email", "device"].includes(method)
+    (method: string) =>
+      !["mobile", "email", "device", "wechat", "weixin"].includes(method)
   );
   return (
     OAUTH_METHODS?.length > 0 && (
@@ -30,7 +24,7 @@ export function OAuthMethods() {
         <div className="mt-6 flex justify-center gap-4 *:size-12 *:p-2">
           {OAUTH_METHODS?.map((method: string) => (
             <Button
-              asChild
+              aria-label={getOAuthProviderMeta(method).label}
               key={method}
               onClick={async () => {
                 const { data } = await oAuthLogin({
@@ -47,7 +41,7 @@ export function OAuthMethods() {
               size="icon"
               variant="ghost"
             >
-              <Icon icon={icons[method as keyof typeof icons]} />
+              <Icon icon={getOAuthProviderMeta(method).icon} />
             </Button>
           ))}
         </div>

--- a/apps/user/src/sections/bind/index.tsx
+++ b/apps/user/src/sections/bind/index.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "@workspace/ui/components/spinner";
 import { Icon } from "@workspace/ui/composed/icon";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 import Certification from "./certification";
 
 export default function BindPage({
@@ -14,18 +15,19 @@ export default function BindPage({
   children?: ReactNode;
 }) {
   const { t } = useTranslation("auth");
+  const provider = getOAuthProviderMeta(platform);
 
   return (
     <Certification platform={platform}>
       <div className="relative flex h-screen w-full flex-col items-center justify-center overflow-hidden bg-background">
         <div className="flex animate-pulse flex-col items-center gap-4">
           <div className="flex items-center gap-3">
-            <Icon className="size-12" icon={`logos:${platform}`} />
+            <Icon className="size-12" icon={provider.icon} />
             <Spinner className="size-8" />
           </div>
           <div className="flex flex-col items-center gap-2">
             <h1 className="bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-500 bg-clip-text font-black text-transparent text-xl uppercase md:text-2xl dark:from-blue-400 dark:via-indigo-300 dark:to-violet-400">
-              {platform}
+              {provider.label}
             </h1>
             <p className="text-lg text-muted-foreground md:text-xl">
               {t("binding", "Binding account...")}

--- a/apps/user/src/sections/oauth/index.tsx
+++ b/apps/user/src/sections/oauth/index.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "@workspace/ui/components/spinner";
 import { Icon } from "@workspace/ui/composed/icon";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 import Certification from "./certification";
 
 export default function OAuthPage({
@@ -14,18 +15,19 @@ export default function OAuthPage({
   children?: ReactNode;
 }) {
   const { t } = useTranslation("auth");
+  const provider = getOAuthProviderMeta(platform);
 
   return (
     <Certification platform={platform}>
       <div className="relative flex h-screen w-full flex-col items-center justify-center overflow-hidden bg-background">
         <div className="flex animate-pulse flex-col items-center gap-4">
           <div className="flex items-center gap-3">
-            <Icon className="size-12" icon={`logos:${platform}`} />
+            <Icon className="size-12" icon={provider.icon} />
             <Spinner className="size-8" />
           </div>
           <div className="flex flex-col items-center gap-2">
             <h1 className="bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-500 bg-clip-text font-black text-transparent text-xl uppercase md:text-2xl dark:from-blue-400 dark:via-indigo-300 dark:to-violet-400">
-              {platform}
+              {provider.label}
             </h1>
             <p className="text-lg text-muted-foreground md:text-xl">
               {t("authenticating", "Authenticating...")}

--- a/apps/user/src/sections/user/profile/third-party-accounts.tsx
+++ b/apps/user/src/sections/user/profile/third-party-accounts.tsx
@@ -36,6 +36,7 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 import SendCode from "@/sections/auth/send-code";
 import { useGlobalStore } from "@/stores/global";
 
@@ -192,7 +193,7 @@ export default function ThirdPartyAccounts() {
     },
     {
       id: "telegram",
-      icon: "logos:telegram",
+      icon: getOAuthProviderMeta("telegram").icon,
       name: "Telegram",
       type: "OAuth",
       descriptionDefault: "Sign in with Telegram",
@@ -206,7 +207,7 @@ export default function ThirdPartyAccounts() {
     },
     {
       id: "google",
-      icon: "logos:google",
+      icon: getOAuthProviderMeta("google").icon,
       name: "Google",
       type: "OAuth",
       descriptionDefault: "Sign in with Google",

--- a/apps/user/src/stores/global.tsx
+++ b/apps/user/src/stores/global.tsx
@@ -4,8 +4,10 @@ import { create } from "zustand";
 
 export interface GlobalStore {
   common: API.GetGlobalConfigResponse;
+  commonReady: boolean;
   user?: API.User;
   setCommon: (common: Partial<API.GetGlobalConfigResponse>) => void;
+  setCommonReady: (ready: boolean) => void;
   setUser: (user?: API.User) => void;
   getUserInfo: () => Promise<void>;
   getUserSubscribe: (short: string, token: string, type?: string) => string[];
@@ -103,6 +105,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
     oauth_methods: [],
     web_ad: false,
   },
+  commonReady: false,
   user: undefined,
   setCommon: (common) =>
     set((state) => ({
@@ -111,6 +114,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
         ...common,
       },
     })),
+  setCommonReady: (commonReady) => set({ commonReady }),
   setUser: (user) => set({ user }),
   getUserInfo: async () => {
     try {

--- a/apps/user/src/stores/global.tsx
+++ b/apps/user/src/stores/global.tsx
@@ -118,7 +118,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
   setUser: (user) => set({ user }),
   getUserInfo: async () => {
     try {
-      const { data } = await queryUserInfo();
+      const { data } = await queryUserInfo({ skipErrorHandler: true });
       set({ user: data.data });
     } catch (error) {
       console.error("Failed to refresh user:", error);

--- a/apps/user/vite.config.ts
+++ b/apps/user/vite.config.ts
@@ -26,11 +26,16 @@ function versionLockPlugin(): Plugin {
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
+  const allowedHosts = [
+    "ppanel-dev.home.arpa",
+    "admin-ppanel-dev.home.arpa",
+  ];
+  const devtoolsPort = Number(env.VITE_DEVTOOLS_PORT || "42069");
 
   return {
     base: "./",
     plugins: [
-      devtools({ eventBusConfig: { port: 42_069 } }),
+      devtools({ eventBusConfig: { port: devtoolsPort } }),
       tanstackRouter({
         target: "react",
         autoCodeSplitting: true,
@@ -45,6 +50,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      allowedHosts,
       proxy: {
         "/api": {
           target: env.VITE_API_BASE_URL || "https://api.ppanel.dev",

--- a/apps/user/vite.config.ts
+++ b/apps/user/vite.config.ts
@@ -26,10 +26,13 @@ function versionLockPlugin(): Plugin {
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
-  const allowedHosts = [
-    "ppanel-dev.home.arpa",
-    "admin-ppanel-dev.home.arpa",
-  ];
+  // Dev server only: allow custom local domains such as Telepresence routes.
+  // Keep this env-driven so each developer can opt in without baking machine-specific hosts into source.
+  const allowedHosts = env.VITE_ALLOWED_HOSTS
+    ? env.VITE_ALLOWED_HOSTS.split(",")
+        .map((host) => host.trim())
+        .filter(Boolean)
+    : undefined;
   const devtoolsPort = Number(env.VITE_DEVTOOLS_PORT || "42069");
 
   return {

--- a/docker/ppanel-admin-web/Dockerfile
+++ b/docker/ppanel-admin-web/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27-alpine
+
+COPY apps/admin/dist /usr/share/nginx/html

--- a/docker/ppanel-user-web/Dockerfile
+++ b/docker/ppanel-user-web/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27-alpine
+
+COPY apps/user/dist /usr/share/nginx/html

--- a/telepresence-kubeconfig-docker.example.json
+++ b/telepresence-kubeconfig-docker.example.json
@@ -1,0 +1,33 @@
+{
+  "kind": "Config",
+  "apiVersion": "v1",
+  "clusters": [
+    {
+      "name": "default",
+      "cluster": {
+        "server": "https://host.docker.internal:16443",
+        "insecure-skip-tls-verify": true
+      }
+    }
+  ],
+  "users": [
+    {
+      "name": "default",
+      "user": {
+        "client-certificate-data": "<base64-client-certificate-data>",
+        "client-key-data": "<base64-client-key-data>"
+      }
+    }
+  ],
+  "contexts": [
+    {
+      "name": "default",
+      "context": {
+        "cluster": "default",
+        "user": "default",
+        "namespace": "ppanel-dev"
+      }
+    }
+  ],
+  "current-context": "default"
+}


### PR DESCRIPTION
## Summary

- read the admin web version badge from the deployed `/version.lock` file at runtime instead of importing the repo root `package.json` during build
- fall back to the gateway version check response when the version lock file is unavailable

## Why

The dashboard badge was showing the build-time workspace version (`1.4.2`) rather than the version actually deployed with the current static assets. This made the displayed value stale or misleading after deployment changes.

## Impact

- the dashboard now reflects the currently deployed admin frontend version
- the badge no longer depends on a hard-coded build-time package import

## Validation

- `npm exec tsc -- -p apps/admin/tsconfig.json --noEmit`
- `npm exec biome check apps/admin/src/sections/dashboard/components/system-version-card.tsx`
- `npm run build --workspace ppanel-admin-web`
