### PR TITLE
[codex] update web version metadata and title sync

### DIFF
--- a/.github/workflows/ghcr-images.yml
+++ b/.github/workflows/ghcr-images.yml
@@ -1,0 +1,126 @@
+name: Publish GHCR Images
+
+on:
+  push:
+    branches: [main, next, beta, develop]
+    tags:
+      - "v*"
+    paths-ignore:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-assets:
+    name: Build Frontend Assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install deps
+        run: bun install
+
+      - name: Build admin and user apps
+        run: bun run build
+
+      - name: Archive admin dist
+        run: tar -czf ppanel-admin-web-dist.tar.gz -C apps/admin dist
+
+      - name: Archive user dist
+        run: tar -czf ppanel-user-web-dist.tar.gz -C apps/user dist
+
+      - name: Upload admin dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: ppanel-admin-web-dist
+          path: ppanel-admin-web-dist.tar.gz
+          if-no-files-found: error
+
+      - name: Upload user dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: ppanel-user-web-dist
+          path: ppanel-user-web-dist.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    needs: build-assets
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ppanel-admin-web
+            artifact: ppanel-admin-web-dist
+            tarball: ppanel-admin-web-dist.tar.gz
+            extract_path: apps/admin
+            dockerfile: docker/ppanel-admin-web/Dockerfile
+          - image: ppanel-user-web
+            artifact: ppanel-user-web-dist
+            tarball: ppanel-user-web-dist.tar.gz
+            extract_path: apps/user
+            dockerfile: docker/ppanel-user-web/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: .
+
+      - name: Extract build artifact
+        run: tar -xzf ${{ matrix.tarball }} -C ${{ matrix.extract_path }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr-images.yml
+++ b/.github/workflows/ghcr-images.yml
@@ -2,7 +2,7 @@ name: Publish GHCR Images
 
 on:
   push:
-    branches: [main, next, beta, develop]
+    branches: [main, dev]
     tags:
       - "v*"
     paths-ignore:

--- a/.github/workflows/ghcr-images.yml
+++ b/.github/workflows/ghcr-images.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set build version
+        run: echo "PPANEL_WEB_VERSION=sha-${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:

--- a/.github/workflows/promote-release-branch.yml
+++ b/.github/workflows/promote-release-branch.yml
@@ -1,0 +1,114 @@
+name: Promote Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      head_branch:
+        description: Source branch to promote
+        required: true
+        default: dev
+      base_branch:
+        description: Target branch for the release PR
+        required: true
+        default: main
+      pr_title:
+        description: Optional PR title override
+        required: false
+      pr_body:
+        description: Optional PR body override
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Ensure auto-merge is enabled
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          allow_auto_merge="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.allow_auto_merge')"
+          if [ "${allow_auto_merge}" != "true" ]; then
+            echo "GitHub repository setting 'Allow auto-merge' must be enabled before running this workflow." >&2
+            exit 1
+          fi
+
+      - name: Validate branches
+        env:
+          HEAD_BRANCH: ${{ inputs.head_branch }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+        run: |
+          git fetch origin "${HEAD_BRANCH}" "${BASE_BRANCH}"
+
+          if ! git show-ref --verify --quiet "refs/remotes/origin/${HEAD_BRANCH}"; then
+            echo "Missing source branch: ${HEAD_BRANCH}" >&2
+            exit 1
+          fi
+
+          if ! git show-ref --verify --quiet "refs/remotes/origin/${BASE_BRANCH}"; then
+            echo "Missing target branch: ${BASE_BRANCH}" >&2
+            exit 1
+          fi
+
+      - name: Create or reuse release PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ inputs.head_branch }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          PR_TITLE: ${{ inputs.pr_title }}
+          PR_BODY: ${{ inputs.pr_body }}
+        run: |
+          existing_pr="$(gh pr list \
+            --base "${BASE_BRANCH}" \
+            --head "${HEAD_BRANCH}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [ -n "${existing_pr}" ]; then
+            echo "number=${existing_pr}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          title="${PR_TITLE}"
+          if [ -z "${title}" ]; then
+            title="release: ${HEAD_BRANCH} -> ${BASE_BRANCH}"
+          fi
+
+          body="${PR_BODY}"
+          if [ -z "${body}" ]; then
+            body="$(printf '%s\n' \
+              '## Summary' \
+              '' \
+              "- promote \`${HEAD_BRANCH}\` into \`${BASE_BRANCH}\`" \
+              '- auto-merge this PR after all required checks pass' \
+              '- let semantic-release publish the frontend release after the merge lands on the target branch')"
+          fi
+
+          pr_url="$(gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${HEAD_BRANCH}" \
+            --title "${title}" \
+            --body "${body}")"
+
+          pr_number="$(gh pr view "${pr_url}" --json number --jq '.number')"
+
+          echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Enable PR auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+        run: |
+          gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch=false
+          echo "Auto-merge enabled for PR #${PR_NUMBER} into ${BASE_BRANCH}"

--- a/.github/workflows/promote-release-branch.yml
+++ b/.github/workflows/promote-release-branch.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -22,7 +22,7 @@ jobs:
           bun-version: 'latest'
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.bun

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build and Release
 
 on:
   push:
-    branches: [main, next, beta, develop]
+    branches: [main, dev]
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ npm-debug.log*
 # Misc
 .DS_Store
 *.pem
+telepresence-kubeconfig-docker.json

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,20 +3,8 @@
   "branches": [
     "main",
     {
-      "name": "beta",
-      "prerelease": true
-    },
-    {
-      "name": "alpha",
-      "prerelease": true
-    },
-    {
-      "name": "develop",
+      "name": "dev",
       "prerelease": "dev"
-    },
-    {
-      "name": "next",
-      "prerelease": true
     }
   ],
   "plugins": [

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,26 +1,6 @@
-# Branch Strategy
+# AGENT Entry
 
-This repository uses a simplified Git Flow model.
+Common branch and worktree instructions are maintained in [BRANCH_STRATEGY.md](./BRANCH_STRATEGY.md).
 
-## Long-lived branches
-- `main` is the production branch.
-- `dev` is the integration branch for daily development.
-
-## Working branches
-- Create feature work on `feat/*` from `dev`.
-- Create bug-fix work on `fix/*` from `dev`.
-- Merge `feat/*` and `fix/*` back into `dev` first.
-- Promote changes from `dev` to `main` through a pull request.
-
-## Protection and deployment rules
-- Never push directly to `main`.
-- `main` must only be updated by a `dev -> main` pull request.
-- The k3s prod environment deploys the latest `main`.
-- The k3s dev environment deploys the latest `dev`.
-
-## Worktree workflow
-```bash
-git fetch origin
-git worktree add ../ppanel-frontend-dev dev
-git worktree add -b feat/your-change ../ppanel-frontend-feat dev
-```
+Agent-specific note:
+- Follow `BRANCH_STRATEGY.md` as the source of truth for branching, promotion, and deployment rules in this repository.

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,26 @@
+# Branch Strategy
+
+This repository uses a simplified Git Flow model.
+
+## Long-lived branches
+- `main` is the production branch.
+- `dev` is the integration branch for daily development.
+
+## Working branches
+- Create feature work on `feat/*` from `dev`.
+- Create bug-fix work on `fix/*` from `dev`.
+- Merge `feat/*` and `fix/*` back into `dev` first.
+- Promote changes from `dev` to `main` through a pull request.
+
+## Protection and deployment rules
+- Never push directly to `main`.
+- `main` must only be updated by a `dev -> main` pull request.
+- The k3s prod environment deploys the latest `main`.
+- The k3s dev environment deploys the latest `dev`.
+
+## Worktree workflow
+```bash
+git fetch origin
+git worktree add ../ppanel-frontend-dev dev
+git worktree add -b feat/your-change ../ppanel-frontend-feat dev
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+<claude-mem-context>
+# Memory Context
+
+# [ppanel-frontend] recent context, 2026-04-17 5:37pm GMT+8
+
+No previous sessions found.
+</claude-mem-context>

--- a/BRANCH_STRATEGY.md
+++ b/BRANCH_STRATEGY.md
@@ -1,26 +1,23 @@
 # Branch Strategy
 
-This repository uses a simplified Git Flow model.
+This repository uses a main-first task branch model.
 
 ## Long-lived branches
-- `main` is the production branch.
-- `dev` is the integration branch for daily development.
+- `main` is the only long-lived development branch.
 
 ## Working branches
-- Create feature work on `feat/*` from `dev`.
-- Create bug-fix work on `fix/*` from `dev`.
-- Merge `feat/*` and `fix/*` back into `dev` first.
-- Promote changes from `dev` to `main` through a pull request.
+- Create feature work on `feat/*` directly from `main`.
+- Create bug-fix work on `fix/*` directly from `main`.
+- Open pull requests from `feat/*` and `fix/*` back into `main`.
 
 ## Protection and deployment rules
 - Never push directly to `main`.
-- `main` must only be updated by a `dev -> main` pull request.
+- `main` must only be updated by task branch pull requests.
 - The k3s prod environment deploys the latest `main`.
-- The k3s dev environment deploys the latest `dev`.
 
 ## Worktree workflow
 ```bash
 git fetch origin
-git worktree add ../ppanel-frontend-dev dev
-git worktree add -b feat/your-change ../ppanel-frontend-feat dev
+git worktree add ../ppanel-frontend-main main
+git worktree add -b feat/your-change ../ppanel-frontend-feat main
 ```

--- a/BRANCH_STRATEGY.md
+++ b/BRANCH_STRATEGY.md
@@ -1,0 +1,26 @@
+# Branch Strategy
+
+This repository uses a simplified Git Flow model.
+
+## Long-lived branches
+- `main` is the production branch.
+- `dev` is the integration branch for daily development.
+
+## Working branches
+- Create feature work on `feat/*` from `dev`.
+- Create bug-fix work on `fix/*` from `dev`.
+- Merge `feat/*` and `fix/*` back into `dev` first.
+- Promote changes from `dev` to `main` through a pull request.
+
+## Protection and deployment rules
+- Never push directly to `main`.
+- `main` must only be updated by a `dev -> main` pull request.
+- The k3s prod environment deploys the latest `main`.
+- The k3s dev environment deploys the latest `dev`.
+
+## Worktree workflow
+```bash
+git fetch origin
+git worktree add ../ppanel-frontend-dev dev
+git worktree add -b feat/your-change ../ppanel-frontend-feat dev
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,6 @@
-# Branch Strategy
+# CLAUDE Entry
 
-This repository uses a simplified Git Flow model.
+Common branch and worktree instructions are maintained in [BRANCH_STRATEGY.md](./BRANCH_STRATEGY.md).
 
-## Long-lived branches
-- `main` is the production branch.
-- `dev` is the integration branch for daily development.
-
-## Working branches
-- Create feature work on `feat/*` from `dev`.
-- Create bug-fix work on `fix/*` from `dev`.
-- Merge `feat/*` and `fix/*` back into `dev` first.
-- Promote changes from `dev` to `main` through a pull request.
-
-## Protection and deployment rules
-- Never push directly to `main`.
-- `main` must only be updated by a `dev -> main` pull request.
-- The k3s prod environment deploys the latest `main`.
-- The k3s dev environment deploys the latest `dev`.
-
-## Worktree workflow
-```bash
-git fetch origin
-git worktree add ../ppanel-frontend-dev dev
-git worktree add -b feat/your-change ../ppanel-frontend-feat dev
-```
+Claude-specific note:
+- Follow `BRANCH_STRATEGY.md` as the shared source of truth before making branch, PR, or deployment decisions in this repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# Branch Strategy
+
+This repository uses a simplified Git Flow model.
+
+## Long-lived branches
+- `main` is the production branch.
+- `dev` is the integration branch for daily development.
+
+## Working branches
+- Create feature work on `feat/*` from `dev`.
+- Create bug-fix work on `fix/*` from `dev`.
+- Merge `feat/*` and `fix/*` back into `dev` first.
+- Promote changes from `dev` to `main` through a pull request.
+
+## Protection and deployment rules
+- Never push directly to `main`.
+- `main` must only be updated by a `dev -> main` pull request.
+- The k3s prod environment deploys the latest `main`.
+- The k3s dev environment deploys the latest `dev`.
+
+## Worktree workflow
+```bash
+git fetch origin
+git worktree add ../ppanel-frontend-dev dev
+git worktree add -b feat/your-change ../ppanel-frontend-feat dev
+```

--- a/apps/admin/src/routes/__root.tsx
+++ b/apps/admin/src/routes/__root.tsx
@@ -8,8 +8,67 @@ import { getCookie } from "@workspace/ui/lib/cookies";
 import { getGlobalConfig } from "@workspace/ui/services/common/common";
 import { isBrowser } from "@workspace/ui/utils/index";
 import { useEffect } from "react";
-import { Helmet, HelmetProvider } from "react-helmet-async";
 import { useGlobalStore } from "@/stores/global";
+
+function syncDocumentHead({
+  title,
+  description,
+  keywords,
+  canonicalUrl,
+  iconHref,
+}: {
+  title: string;
+  description?: string;
+  keywords?: string;
+  canonicalUrl?: string;
+  iconHref?: string;
+}) {
+  document.title = title;
+
+  const upsertMeta = (name: string, content?: string) => {
+    let element = document.head.querySelector<HTMLMetaElement>(
+      `meta[name="${name}"]`
+    );
+
+    if (!content) {
+      element?.remove();
+      return;
+    }
+
+    if (!element) {
+      element = document.createElement("meta");
+      element.name = name;
+      document.head.appendChild(element);
+    }
+
+    element.content = content;
+  };
+
+  const upsertLink = (rel: string, href?: string) => {
+    let element = document.head.querySelector<HTMLLinkElement>(
+      `link[rel="${rel}"]`
+    );
+
+    if (!href) {
+      element?.remove();
+      return;
+    }
+
+    if (!element) {
+      element = document.createElement("link");
+      element.rel = rel;
+      document.head.appendChild(element);
+    }
+
+    element.href = href;
+  };
+
+  upsertMeta("description", description);
+  upsertMeta("keywords", keywords);
+  upsertLink("canonical", canonicalUrl);
+  upsertLink("icon", iconHref);
+  upsertLink("apple-touch-icon", iconHref);
+}
 
 export const Route = createRootRouteWithContext()({
   component: () => {
@@ -37,23 +96,26 @@ export const Route = createRootRouteWithContext()({
     }, []);
 
     const { site } = common;
-    const title = site.site_name || "Loading...";
-    const description = site.site_desc || "";
+    const title = site.site_name || "Perfect Panel";
+    const description = site.site_desc || title;
     const keywords = site.keywords || "";
     const logo = site.site_logo || "";
     const url = isBrowser() ? window.location.href : "";
 
+    useEffect(() => {
+      if (!isBrowser()) return;
+
+      syncDocumentHead({
+        title,
+        description,
+        keywords,
+        canonicalUrl: url,
+        iconHref: logo,
+      });
+    }, [description, keywords, logo, title, url]);
+
     return (
-      <HelmetProvider>
-        <Helmet>
-          <title>{title}</title>
-          <meta content={description} name="description" />
-          <meta content={keywords} name="keywords" />
-          <link href={url} rel="canonical" />
-          <link href={logo} rel="icon" type="image/*" />
-          <link href={logo} rel="apple-touch-icon" sizes="180x180" />
-          <link href="/site.webmanifest" rel="manifest" />
-        </Helmet>
+      <>
         <NavigationProgress />
         <Outlet />
         <Toaster closeButton richColors />
@@ -73,7 +135,7 @@ export const Route = createRootRouteWithContext()({
             TanStackQueryDevtools,
           ]}
         />
-      </HelmetProvider>
+      </>
     );
   },
 });

--- a/apps/admin/src/sections/auth/index.tsx
+++ b/apps/admin/src/sections/auth/index.tsx
@@ -20,9 +20,9 @@ export default function Auth() {
   }, [navigate, user]);
 
   return (
-    <main className="flex h-full min-h-screen items-center bg-muted/50">
+    <main className="flex h-full min-h-screen items-center bg-muted/50 [&_canvas]:pointer-events-none">
       <div className="flex size-full flex-auto flex-col justify-center lg:flex-row">
-        <div className="flex lg:w-1/2 lg:flex-auto">
+        <div className="flex lg:pointer-events-none lg:w-1/2 lg:flex-auto">
           <div className="flex w-full flex-col items-center justify-center px-5 py-4 md:px-14 lg:py-14">
             <Link className="mb-0 flex flex-col items-center lg:mb-12" to="/">
               <img
@@ -35,7 +35,7 @@ export default function Auth() {
             </Link>
             <DotLottieReact
               autoplay
-              className="mx-auto hidden w-full lg:block"
+              className="pointer-events-none mx-auto hidden w-full lg:block"
               loop
               src="./assets/lotties/login.json"
             />
@@ -44,8 +44,8 @@ export default function Auth() {
             </p>
           </div>
         </div>
-        <div className="flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
-          <div className="flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
+        <div className="relative z-10 flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
+          <div className="relative z-10 flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
             <div className="flex flex-col items-stretch justify-center md:w-[400px] lg:h-full">
               <div className="flex flex-col justify-center pb-14 lg:flex-auto lg:pb-20">
                 <EmailAuthForm />

--- a/apps/admin/src/sections/auth/index.tsx
+++ b/apps/admin/src/sections/auth/index.tsx
@@ -20,9 +20,9 @@ export default function Auth() {
   }, [navigate, user]);
 
   return (
-    <main className="flex h-full min-h-screen items-center bg-muted/50">
+    <main className="flex h-full min-h-screen items-center bg-muted/50 [&_canvas]:pointer-events-none">
       <div className="flex size-full flex-auto flex-col justify-center lg:flex-row">
-        <div className="flex lg:w-1/2 lg:flex-auto">
+        <div className="flex lg:w-1/2 lg:flex-auto lg:pointer-events-none">
           <div className="flex w-full flex-col items-center justify-center px-5 py-4 md:px-14 lg:py-14">
             <Link className="mb-0 flex flex-col items-center lg:mb-12" to="/">
               <img
@@ -35,7 +35,7 @@ export default function Auth() {
             </Link>
             <DotLottieReact
               autoplay
-              className="mx-auto hidden w-full lg:block"
+              className="pointer-events-none mx-auto hidden w-full lg:block"
               loop
               src="./assets/lotties/login.json"
             />
@@ -44,8 +44,8 @@ export default function Auth() {
             </p>
           </div>
         </div>
-        <div className="flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
-          <div className="flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
+        <div className="relative z-10 flex flex-initial justify-center p-8 lg:flex-auto lg:justify-end">
+          <div className="relative z-10 flex flex-col items-center rounded-2xl md:w-[600px] lg:flex-auto lg:bg-background lg:p-10 lg:shadow">
             <div className="flex flex-col items-stretch justify-center md:w-[400px] lg:h-full">
               <div className="flex flex-col justify-center pb-14 lg:flex-auto lg:pb-20">
                 <EmailAuthForm />

--- a/apps/admin/src/sections/auth/index.tsx
+++ b/apps/admin/src/sections/auth/index.tsx
@@ -21,7 +21,7 @@ export default function Auth() {
 
   return (
     <main className="flex h-full min-h-screen items-center bg-muted/50 [&_canvas]:pointer-events-none">
-        <div className="flex size-full flex-auto flex-col justify-center lg:flex-row">
+      <div className="flex size-full flex-auto flex-col justify-center lg:flex-row">
         <div className="flex lg:pointer-events-none lg:w-1/2 lg:flex-auto">
           <div className="flex w-full flex-col items-center justify-center px-5 py-4 md:px-14 lg:py-14">
             <Link className="mb-0 flex flex-col items-center lg:mb-12" to="/">

--- a/apps/admin/src/sections/dashboard/components/system-version-card.tsx
+++ b/apps/admin/src/sections/dashboard/components/system-version-card.tsx
@@ -28,36 +28,55 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
-async function getDeployedWebVersion() {
-  if (import.meta.env.DEV) {
-    return import.meta.env.VITE_APP_VERSION || "-";
-  }
-
-  const response = await fetch(new URL("/version.lock", window.location.origin), {
-    cache: "no-store",
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to load version.lock: ${response.status}`);
-  }
-
-  const version = (await response.text()).trim();
-
-  // Guard against dev-server/ingress fallbacks returning index.html for a
-  // missing asset, which would otherwise be rendered as the version string.
-  if (!version || version.startsWith("<!DOCTYPE html") || version.startsWith("<html")) {
-    throw new Error("Invalid version.lock payload");
-  }
-
-  return version;
+interface WebVersionMetadata {
+  commit: string;
+  tag: string | null;
+  display_version: string;
 }
 
-function formatVersionBadge(version?: string) {
-  if (!version || version === "-") {
-    return "-";
+function isWebVersionMetadata(value: unknown): value is WebVersionMetadata {
+  if (!(value && typeof value === "object")) return false;
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.commit === "string" &&
+    candidate.commit.length > 0 &&
+    (candidate.tag === null || typeof candidate.tag === "string") &&
+    typeof candidate.display_version === "string" &&
+    candidate.display_version.length > 0
+  );
+}
+
+function parseWebVersionMetadata(text: string) {
+  try {
+    const payload = JSON.parse(text) as unknown;
+    if (isWebVersionMetadata(payload)) return payload;
+  } catch {
+    return null;
   }
 
-  return /^[0-9]/.test(version) ? `V${version}` : version;
+  return null;
+}
+
+async function getDeployedWebVersion() {
+  try {
+    const response = await fetch(
+      new URL("version.json", window.location.href),
+      {
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+        },
+      }
+    );
+
+    if (!response.ok) return null;
+
+    const text = await response.text();
+    return parseWebVersionMetadata(text);
+  } catch {
+    return null;
+  }
 }
 
 export default function SystemVersionCard() {
@@ -68,6 +87,7 @@ export default function SystemVersionCard() {
   const [openUpdateWeb, setOpenUpdateWeb] = useState(false);
   const [openUpdateServer, setOpenUpdateServer] = useState(false);
   const [isUpdatingWeb, setIsUpdatingWeb] = useState(false);
+  const injectedWebVersion = __APP_GIT_VERSION__;
 
   const { data: moduleConfig } = useQuery({
     queryKey: ["getModuleConfig"],
@@ -115,8 +135,9 @@ export default function SystemVersionCard() {
   const { data: deployedWebVersion } = useQuery({
     queryKey: ["deployedWebVersion"],
     queryFn: getDeployedWebVersion,
+    enabled: !import.meta.env.DEV,
     staleTime: 0,
-    retry: 1,
+    retry: false,
   });
 
   const updateServerMutation = useMutation({
@@ -167,9 +188,10 @@ export default function SystemVersionCard() {
   const hasWebNewVersion = webVersionInfo?.has_update ?? false;
   const isUpdatingServer = updateServerMutation.isPending;
   const currentWebVersion =
-    deployedWebVersion || webVersionInfo?.current_version || "-";
-  const currentServerVersion =
-    moduleConfig?.service_version || serverVersionInfo?.current_version || "1.0.0";
+    deployedWebVersion?.display_version ||
+    injectedWebVersion?.display_version ||
+    webVersionInfo?.current_version ||
+    "-";
 
   return (
     <Card className="gap-0 p-3">
@@ -229,7 +251,7 @@ export default function SystemVersionCard() {
             </span>
           </div>
           <div className="flex items-center space-x-2">
-            <Badge>{formatVersionBadge(currentWebVersion)}</Badge>
+            <Badge>{currentWebVersion}</Badge>
             <AlertDialog onOpenChange={setOpenUpdateWeb} open={openUpdateWeb}>
               <AlertDialogTrigger asChild>
                 <Button
@@ -238,31 +260,24 @@ export default function SystemVersionCard() {
                   size="sm"
                   variant="outline"
                 >
-                  <Icon className="mr-1 h-3 w-3" icon="mdi:download" />
-                  {hasWebNewVersion && webVersionInfo
-                    ? `${t("update", "Update")} ${webVersionInfo.latest_version}`
-                    : t("update", "Update")}
+                  {isUpdatingWeb && (
+                    <Icon className="mr-1 animate-spin" icon="mdi:loading" />
+                  )}
+                  {hasWebNewVersion
+                    ? t("upgrade", "Upgrade")
+                    : t("latestVersion", "Latest Version")}
                 </Button>
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
                   <AlertDialogTitle>
-                    {t("confirmUpdate", "Confirm Update")}
+                    {t("confirmUpdateWeb", "Confirm Update Web")}
                   </AlertDialogTitle>
                   <AlertDialogDescription>
-                    {webVersionInfo
-                      ? t(
-                          "updateWebDescription",
-                          "Are you sure you want to update the web version from {{current}} to {{latest}}?",
-                          {
-                            current: webVersionInfo.current_version,
-                            latest: webVersionInfo.latest_version,
-                          }
-                        )
-                      : t(
-                          "updateDescription",
-                          "Are you sure you want to update?"
-                        )}
+                    {t(
+                      "updateWebDescription",
+                      "Are you sure you want to update admin and user web services? This may cause temporary interruption."
+                    )}
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
@@ -271,14 +286,15 @@ export default function SystemVersionCard() {
                     {isUpdatingWeb && (
                       <Icon className="mr-2 animate-spin" icon="mdi:loading" />
                     )}
-                    {t("confirmUpdate", "Confirm Update")}
+                    {isUpdatingWeb
+                      ? t("updating", "Updating...")
+                      : t("confirm", "Confirm")}
                   </Button>
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
           </div>
         </div>
-
         <div className="flex flex-1 items-center justify-between">
           <div className="flex items-center">
             <Icon className="mr-2 h-4 w-4 text-blue-600" icon="mdi:server" />
@@ -287,7 +303,7 @@ export default function SystemVersionCard() {
             </span>
           </div>
           <div className="flex items-center space-x-2">
-            <Badge>{formatVersionBadge(currentServerVersion)}</Badge>
+            <Badge>{moduleConfig?.service_version || "1.0.0"}</Badge>
             <AlertDialog
               onOpenChange={setOpenUpdateServer}
               open={openUpdateServer}
@@ -299,48 +315,40 @@ export default function SystemVersionCard() {
                   size="sm"
                   variant="outline"
                 >
-                  <Icon className="mr-1 h-3 w-3" icon="mdi:download" />
-                  {hasServerNewVersion && serverVersionInfo
-                    ? `${t("update", "Update")} ${serverVersionInfo.latest_version}`
-                    : t("update", "Update")}
+                  {isUpdatingServer && (
+                    <Icon className="mr-1 animate-spin" icon="mdi:loading" />
+                  )}
+                  {hasServerNewVersion
+                    ? t("upgrade", "Upgrade")
+                    : t("latestVersion", "Latest Version")}
                 </Button>
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
                   <AlertDialogTitle>
-                    {t("confirmUpdate", "Confirm Update")}
+                    {t("confirmUpdateServer", "Confirm Update Server")}
                   </AlertDialogTitle>
                   <AlertDialogDescription>
-                    {serverVersionInfo && moduleConfig
-                      ? t(
-                          "updateServerDescription",
-                          "Are you sure you want to update the server version from {{current}} to {{latest}}?",
-                          {
-                            current:
-                              moduleConfig.service_version ||
-                              serverVersionInfo.current_version,
-                            latest: serverVersionInfo.latest_version,
-                          }
-                        )
-                      : t(
-                          "updateDescription",
-                          "Are you sure you want to update?"
-                        )}
+                    {t(
+                      "updateServerDescription",
+                      "Are you sure you want to update the server service? This may cause temporary interruption."
+                    )}
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                   <AlertDialogCancel>{t("cancel", "Cancel")}</AlertDialogCancel>
                   <Button
-                    disabled={isUpdatingServer || !moduleConfig}
+                    disabled={isUpdatingServer}
                     onClick={() =>
-                      moduleConfig &&
-                      updateServerMutation.mutate(moduleConfig.service_name)
+                      updateServerMutation.mutate(moduleConfig!.service_name)
                     }
                   >
                     {isUpdatingServer && (
                       <Icon className="mr-2 animate-spin" icon="mdi:loading" />
                     )}
-                    {t("confirmUpdate", "Confirm Update")}
+                    {isUpdatingServer
+                      ? t("updating", "Updating...")
+                      : t("confirm", "Confirm")}
                   </Button>
                 </AlertDialogFooter>
               </AlertDialogContent>

--- a/apps/admin/src/sections/dashboard/components/system-version-card.tsx
+++ b/apps/admin/src/sections/dashboard/components/system-version-card.tsx
@@ -29,7 +29,11 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 async function getDeployedWebVersion() {
-  const response = await fetch(new URL("version.lock", window.location.href), {
+  if (import.meta.env.DEV) {
+    return import.meta.env.VITE_APP_VERSION || "-";
+  }
+
+  const response = await fetch(new URL("/version.lock", window.location.origin), {
     cache: "no-store",
   });
 
@@ -37,7 +41,23 @@ async function getDeployedWebVersion() {
     throw new Error(`Failed to load version.lock: ${response.status}`);
   }
 
-  return (await response.text()).trim();
+  const version = (await response.text()).trim();
+
+  // Guard against dev-server/ingress fallbacks returning index.html for a
+  // missing asset, which would otherwise be rendered as the version string.
+  if (!version || version.startsWith("<!DOCTYPE html") || version.startsWith("<html")) {
+    throw new Error("Invalid version.lock payload");
+  }
+
+  return version;
+}
+
+function formatVersionBadge(version?: string) {
+  if (!version || version === "-") {
+    return "-";
+  }
+
+  return /^[0-9]/.test(version) ? `V${version}` : version;
 }
 
 export default function SystemVersionCard() {
@@ -148,6 +168,8 @@ export default function SystemVersionCard() {
   const isUpdatingServer = updateServerMutation.isPending;
   const currentWebVersion =
     deployedWebVersion || webVersionInfo?.current_version || "-";
+  const currentServerVersion =
+    moduleConfig?.service_version || serverVersionInfo?.current_version || "1.0.0";
 
   return (
     <Card className="gap-0 p-3">
@@ -207,7 +229,7 @@ export default function SystemVersionCard() {
             </span>
           </div>
           <div className="flex items-center space-x-2">
-            <Badge>V{currentWebVersion}</Badge>
+            <Badge>{formatVersionBadge(currentWebVersion)}</Badge>
             <AlertDialog onOpenChange={setOpenUpdateWeb} open={openUpdateWeb}>
               <AlertDialogTrigger asChild>
                 <Button
@@ -265,12 +287,7 @@ export default function SystemVersionCard() {
             </span>
           </div>
           <div className="flex items-center space-x-2">
-            <Badge>
-              V
-              {moduleConfig?.service_version ||
-                serverVersionInfo?.current_version ||
-                "1.0.0"}
-            </Badge>
+            <Badge>{formatVersionBadge(currentServerVersion)}</Badge>
             <AlertDialog
               onOpenChange={setOpenUpdateServer}
               open={openUpdateServer}

--- a/apps/admin/src/sections/dashboard/components/system-version-card.tsx
+++ b/apps/admin/src/sections/dashboard/components/system-version-card.tsx
@@ -27,7 +27,18 @@ import { basicUpdateService } from "@workspace/ui/services/gateway/basicUpdateSe
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import packageJson from "../../../../../../package.json";
+
+async function getDeployedWebVersion() {
+  const response = await fetch(new URL("version.lock", window.location.href), {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load version.lock: ${response.status}`);
+  }
+
+  return (await response.text()).trim();
+}
 
 export default function SystemVersionCard() {
   const { t } = useTranslation("tool");
@@ -81,6 +92,13 @@ export default function SystemVersionCard() {
     retry: 1,
   });
 
+  const { data: deployedWebVersion } = useQuery({
+    queryKey: ["deployedWebVersion"],
+    queryFn: getDeployedWebVersion,
+    staleTime: 0,
+    retry: 1,
+  });
+
   const updateServerMutation = useMutation({
     mutationFn: async (serviceName: string) => {
       await basicUpdateService({
@@ -128,6 +146,8 @@ export default function SystemVersionCard() {
   const hasServerNewVersion = serverVersionInfo?.has_update ?? false;
   const hasWebNewVersion = webVersionInfo?.has_update ?? false;
   const isUpdatingServer = updateServerMutation.isPending;
+  const currentWebVersion =
+    deployedWebVersion || webVersionInfo?.current_version || "-";
 
   return (
     <Card className="gap-0 p-3">
@@ -187,7 +207,7 @@ export default function SystemVersionCard() {
             </span>
           </div>
           <div className="flex items-center space-x-2">
-            <Badge>V{packageJson.version}</Badge>
+            <Badge>V{currentWebVersion}</Badge>
             <AlertDialog onOpenChange={setOpenUpdateWeb} open={openUpdateWeb}>
               <AlertDialogTrigger asChild>
                 <Button

--- a/apps/admin/src/stores/global.tsx
+++ b/apps/admin/src/stores/global.tsx
@@ -114,7 +114,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
   setUser: (user) => set({ user }),
   getUserInfo: async () => {
     try {
-      const { data } = await currentUser();
+      const { data } = await currentUser({ skipErrorHandler: true });
       set({ user: data.data });
     } catch (error) {
       console.error("Failed to refresh user:", error);

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,23 +1,24 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { fileURLToPath, URL } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
 import { devtools } from "@tanstack/devtools-vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig, loadEnv, type Plugin } from "vite";
+import { resolveWebVersion } from "../../tools/resolve-web-version";
 
-// Plugin to generate version.lock file after build
+function resolveBuildVersion() {
+  const gitRoot = fileURLToPath(new URL("../../", import.meta.url));
+  return resolveWebVersion(gitRoot);
+}
+
 function versionLockPlugin(): Plugin {
   return {
     name: "version-lock",
     apply: "build",
     closeBundle() {
       const distDir = fileURLToPath(new URL("./dist", import.meta.url));
-      const rootPkgPath = fileURLToPath(
-        new URL("../../package.json", import.meta.url)
-      );
-      const rootPkg = JSON.parse(readFileSync(rootPkgPath, "utf-8"));
-      const version = rootPkg.version || "0.0.0";
+      const version = resolveBuildVersion();
 
       mkdirSync(distDir, { recursive: true });
       writeFileSync(`${distDir}/version.lock`, version);
@@ -26,13 +27,27 @@ function versionLockPlugin(): Plugin {
 }
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), "");
+  const webVersion = resolveBuildVersion();
+  // Dev server only: allow custom local domains such as Telepresence routes.
+  // Keep this env-driven so each developer can opt in without baking machine-specific hosts into source.
+  const allowedHosts = env.VITE_ALLOWED_HOSTS
+    ? env.VITE_ALLOWED_HOSTS.split(",")
+        .map((host) => host.trim())
+        .filter(Boolean)
+    : undefined;
+  const devtoolsPort = Number(env.VITE_DEVTOOLS_PORT || "42070");
 
   return {
-    base: "./",
+    // Vite dev server should serve modules from an absolute root path so
+    // Telepresence-hosted local domains can resolve lazy chunks correctly.
+    base: command === "serve" ? "/" : "./",
+    define: {
+      "import.meta.env.VITE_APP_VERSION": JSON.stringify(webVersion),
+    },
     plugins: [
-      devtools({ eventBusConfig: { port: 42_070 } }),
+      devtools({ eventBusConfig: { port: devtoolsPort } }),
       tanstackRouter({
         target: "react",
         autoCodeSplitting: true,
@@ -47,6 +62,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      allowedHosts,
       proxy: {
         "/api": {
           target: env.VITE_API_BASE_URL || "https://api.ppanel.dev",

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -5,56 +5,50 @@ import { devtools } from "@tanstack/devtools-vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig, loadEnv, type Plugin } from "vite";
-import { resolveWebVersion } from "../../tools/resolve-web-version";
+import { resolveWebVersion } from "../../src/build/resolve-web-version";
 
-function resolveBuildVersion() {
-  const gitRoot = fileURLToPath(new URL("../../", import.meta.url));
-  return resolveWebVersion(gitRoot);
-}
-
-function versionLockPlugin(): Plugin {
+// Plugin to generate version metadata after build
+function versionMetadataPlugin(): Plugin {
   return {
-    name: "version-lock",
+    name: "version-metadata",
     apply: "build",
     closeBundle() {
       const distDir = fileURLToPath(new URL("./dist", import.meta.url));
-      const version = resolveBuildVersion();
+      const version = resolveWebVersion();
 
       mkdirSync(distDir, { recursive: true });
-      writeFileSync(`${distDir}/version.lock`, version);
+      writeFileSync(
+        `${distDir}/version.json`,
+        JSON.stringify(version, null, 2)
+      );
     },
   };
 }
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode, command }) => {
+export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
-  const webVersion = resolveBuildVersion();
-  // Dev server only: allow custom local domains such as Telepresence routes.
-  // Keep this env-driven so each developer can opt in without baking machine-specific hosts into source.
+  const webVersion = resolveWebVersion();
   const allowedHosts = env.VITE_ALLOWED_HOSTS
     ? env.VITE_ALLOWED_HOSTS.split(",")
         .map((host) => host.trim())
         .filter(Boolean)
     : undefined;
-  const devtoolsPort = Number(env.VITE_DEVTOOLS_PORT || "42070");
 
   return {
-    // Vite dev server should serve modules from an absolute root path so
-    // Telepresence-hosted local domains can resolve lazy chunks correctly.
-    base: command === "serve" ? "/" : "./",
+    base: "./",
     define: {
-      "import.meta.env.VITE_APP_VERSION": JSON.stringify(webVersion),
+      __APP_GIT_VERSION__: JSON.stringify(webVersion),
     },
     plugins: [
-      devtools({ eventBusConfig: { port: devtoolsPort } }),
+      devtools({ eventBusConfig: { port: 42_070 } }),
       tanstackRouter({
         target: "react",
         autoCodeSplitting: true,
       }),
       viteReact(),
       tailwindcss(),
-      versionLockPlugin(),
+      versionMetadataPlugin(),
     ],
     resolve: {
       alias: {

--- a/apps/user/.env.example
+++ b/apps/user/.env.example
@@ -16,3 +16,12 @@ VITE_SHOW_LANDING_PAGE=true
 # Default login credentials (for development only)
 VITE_USER_EMAIL=
 VITE_USER_PASSWORD=
+
+# Vite dev server allowed hosts (development only, comma-separated).
+# Used by the local Telepresence workflow in ../ppanel-script/telepresence.sh.
+# Use a leading dot to allow a domain and all its subdomains, for example `.home.arpa`.
+VITE_ALLOWED_HOSTS=
+
+# TanStack devtools event bus port (development only).
+# Can be overridden when starting via ../ppanel-script/telepresence.sh.
+VITE_DEVTOOLS_PORT=42069

--- a/apps/user/.env.production
+++ b/apps/user/.env.production
@@ -1,2 +1,4 @@
+# Use same-origin requests in production; ingress handles /api -> backend routing.
+VITE_API_BASE_URL=
 # Route browser API requests through the ingress rewrite in production.
 VITE_API_PREFIX=/api

--- a/apps/user/.env.production
+++ b/apps/user/.env.production
@@ -1,0 +1,2 @@
+# Route browser API requests through the ingress rewrite in production.
+VITE_API_PREFIX=/api

--- a/apps/user/public/assets/locales/en-US/auth.json
+++ b/apps/user/public/assets/locales/en-US/auth.json
@@ -2,6 +2,8 @@
   "authenticating": "Authenticating...",
   "binding": "Binding account...",
   "get": "Get Code",
+  "loadingAuth": "Loading sign-in options...",
+  "loadingAuthDesc": "Please wait while we prepare your account access.",
   "login": {
     "codeLogin": "Login with Code",
     "email": "Please enter a valid email address",
@@ -11,6 +13,8 @@
     "success": "Login successful!",
     "title": "Login"
   },
+  "noAuthMethods": "No direct sign-in methods are available",
+  "noAuthMethodsDesc": "Use the third-party sign-in options below, or contact support if this looks unexpected.",
   "privacyPolicy": "Privacy Policy",
   "register": {
     "email": "Please enter a valid email address",

--- a/apps/user/public/assets/locales/zh-CN/auth.json
+++ b/apps/user/public/assets/locales/zh-CN/auth.json
@@ -2,6 +2,8 @@
   "authenticating": "正在认证...",
   "binding": "正在绑定账号...",
   "get": "获取验证码",
+  "loadingAuth": "正在加载登录方式...",
+  "loadingAuthDesc": "请稍候，我们正在准备您的账户访问方式。",
   "login": {
     "codeLogin": "验证码登录",
     "email": "请输入有效的邮箱地址",
@@ -11,6 +13,8 @@
     "success": "登录成功！",
     "title": "登录"
   },
+  "noAuthMethods": "当前没有可用的直接登录方式",
+  "noAuthMethodsDesc": "请使用下方第三方登录方式，或在异常情况下联系支持。",
   "privacyPolicy": "隐私政策",
   "register": {
     "email": "请输入有效的邮箱地址",

--- a/apps/user/public/bind/google/index.html
+++ b/apps/user/public/bind/google/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bind Redirect</title>
+    <meta http-equiv="refresh" content="0; url=/#/profile">
+    <script>
+    "use strict";
+
+    (() => {
+      try {
+        let path = window.location.pathname || "/";
+        path = path.replace(/\/$/, "");
+
+        const search = window.location.search || "";
+        const target = `/#${path}${search}`;
+        window.location.replace(target);
+      } catch (_e) {
+        window.location.replace("/#/profile");
+      }
+    })();
+    </script>
+  </head>
+  <body>Redirecting…</body>
+</html>

--- a/apps/user/public/bind/telegram/index.html
+++ b/apps/user/public/bind/telegram/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bind Redirect</title>
+    <meta http-equiv="refresh" content="0; url=/#/profile">
+    <script>
+    "use strict";
+
+    (() => {
+      try {
+        let path = window.location.pathname || "/";
+        path = path.replace(/\/$/, "");
+
+        const search = window.location.search || "";
+        const target = `/#${path}${search}`;
+        window.location.replace(target);
+      } catch (_e) {
+        window.location.replace("/#/profile");
+      }
+    })();
+    </script>
+  </head>
+  <body>Redirecting…</body>
+</html>

--- a/apps/user/src/config/oauth-providers.ts
+++ b/apps/user/src/config/oauth-providers.ts
@@ -1,0 +1,37 @@
+export const OAUTH_PROVIDER_META: Record<
+  string,
+  {
+    icon: string;
+    label: string;
+  }
+> = {
+  apple: {
+    icon: "uil:apple",
+    label: "Apple",
+  },
+  facebook: {
+    icon: "logos:facebook",
+    label: "Facebook",
+  },
+  github: {
+    icon: "uil:github",
+    label: "GitHub",
+  },
+  google: {
+    icon: "logos:google-icon",
+    label: "Google",
+  },
+  telegram: {
+    icon: "logos:telegram",
+    label: "Telegram",
+  },
+};
+
+export function getOAuthProviderMeta(provider: string) {
+  return (
+    OAUTH_PROVIDER_META[provider] || {
+      icon: "mdi:account-circle-outline",
+      label: provider,
+    }
+  );
+}

--- a/apps/user/src/routes/__root.tsx
+++ b/apps/user/src/routes/__root.tsx
@@ -13,7 +13,7 @@ import { useGlobalStore } from "@/stores/global";
 
 export const Route = createRootRouteWithContext()({
   component: () => {
-    const { common, setCommon, getUserInfo } = useGlobalStore();
+    const { common, setCommon, setCommonReady, getUserInfo } = useGlobalStore();
     useEffect(() => {
       const initializeApp = async () => {
         try {
@@ -30,11 +30,13 @@ export const Route = createRootRouteWithContext()({
           }
         } catch (error) {
           console.error("Failed to initialize app:", error);
+        } finally {
+          setCommonReady(true);
         }
       };
 
       initializeApp();
-    }, []);
+    }, [getUserInfo, setCommon, setCommonReady]);
 
     const { site } = common;
     const title = site.site_name || "Loading...";

--- a/apps/user/src/routes/__root.tsx
+++ b/apps/user/src/routes/__root.tsx
@@ -8,8 +8,67 @@ import { getCookie } from "@workspace/ui/lib/cookies";
 import { getGlobalConfig } from "@workspace/ui/services/common/common";
 import { isBrowser } from "@workspace/ui/utils/index";
 import { useEffect } from "react";
-import { Helmet, HelmetProvider } from "react-helmet-async";
 import { useGlobalStore } from "@/stores/global";
+
+function syncDocumentHead({
+  title,
+  description,
+  keywords,
+  canonicalUrl,
+  iconHref,
+}: {
+  title: string;
+  description?: string;
+  keywords?: string;
+  canonicalUrl?: string;
+  iconHref?: string;
+}) {
+  document.title = title;
+
+  const upsertMeta = (name: string, content?: string) => {
+    let element = document.head.querySelector<HTMLMetaElement>(
+      `meta[name="${name}"]`
+    );
+
+    if (!content) {
+      element?.remove();
+      return;
+    }
+
+    if (!element) {
+      element = document.createElement("meta");
+      element.name = name;
+      document.head.appendChild(element);
+    }
+
+    element.content = content;
+  };
+
+  const upsertLink = (rel: string, href?: string) => {
+    let element = document.head.querySelector<HTMLLinkElement>(
+      `link[rel="${rel}"]`
+    );
+
+    if (!href) {
+      element?.remove();
+      return;
+    }
+
+    if (!element) {
+      element = document.createElement("link");
+      element.rel = rel;
+      document.head.appendChild(element);
+    }
+
+    element.href = href;
+  };
+
+  upsertMeta("description", description);
+  upsertMeta("keywords", keywords);
+  upsertLink("canonical", canonicalUrl);
+  upsertLink("icon", iconHref);
+  upsertLink("apple-touch-icon", iconHref);
+}
 
 export const Route = createRootRouteWithContext()({
   component: () => {
@@ -39,23 +98,26 @@ export const Route = createRootRouteWithContext()({
     }, [getUserInfo, setCommon, setCommonReady]);
 
     const { site } = common;
-    const title = site.site_name || "Loading...";
-    const description = site.site_desc || "";
+    const title = site.site_name || "Perfect Panel";
+    const description = site.site_desc || title;
     const keywords = site.keywords || "";
     const logo = site.site_logo || "";
     const url = isBrowser() ? window.location.href : "";
 
+    useEffect(() => {
+      if (!isBrowser()) return;
+
+      syncDocumentHead({
+        title,
+        description,
+        keywords,
+        canonicalUrl: url,
+        iconHref: logo,
+      });
+    }, [description, keywords, logo, title, url]);
+
     return (
-      <HelmetProvider>
-        <Helmet>
-          <title>{title}</title>
-          <meta content={description} name="description" />
-          <meta content={keywords} name="keywords" />
-          <link href={url} rel="canonical" />
-          <link href={logo} rel="icon" type="image/*" />
-          <link href={logo} rel="apple-touch-icon" sizes="180x180" />
-          <link href="/site.webmanifest" rel="manifest" />
-        </Helmet>
+      <>
         <NavigationProgress />
         <Outlet />
         <Toaster closeButton richColors />
@@ -75,7 +137,7 @@ export const Route = createRootRouteWithContext()({
             TanStackQueryDevtools,
           ]}
         />
-      </HelmetProvider>
+      </>
     );
   },
 });

--- a/apps/user/src/sections/auth/index.tsx
+++ b/apps/user/src/sections/auth/index.tsx
@@ -2,6 +2,7 @@
 
 import { DotLottieReact } from "@lottiefiles/dotlottie-react";
 import { Link } from "@tanstack/react-router";
+import { Spinner } from "@workspace/ui/components/spinner";
 import {
   Tabs,
   TabsContent,
@@ -18,21 +19,83 @@ import PhoneAuthForm from "./phone/auth-form";
 
 export default function Main() {
   const { t } = useTranslation("auth");
-  const { common } = useGlobalStore();
+  const { common, commonReady } = useGlobalStore();
   const { site, auth } = common;
+  const enabledMethods = new Set(common.oauth_methods || []);
 
   const AUTH_METHODS = [
     {
       key: "email",
-      enabled: auth.email.enable,
+      enabled: auth.email.enable || enabledMethods.has("email"),
       children: <EmailAuthForm />,
     },
     {
       key: "mobile",
-      enabled: auth.mobile.enable,
+      enabled: auth.mobile.enable || enabledMethods.has("mobile"),
       children: <PhoneAuthForm />,
     },
   ].filter((method) => method.enabled);
+
+  const renderAuthContent = () => {
+    if (!commonReady) {
+      return (
+        <div className="flex min-h-[320px] flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border/60 bg-muted/20 px-6 text-center">
+          <Spinner className="size-8" />
+          <div>
+            <p className="font-medium text-base">
+              {t("loadingAuth", "Loading sign-in options...")}
+            </p>
+            <p className="text-muted-foreground text-sm">
+              {t(
+                "loadingAuthDesc",
+                "Please wait while we prepare your account access."
+              )}
+            </p>
+          </div>
+        </div>
+      );
+    }
+
+    if (AUTH_METHODS.length === 0) {
+      return (
+        <div className="flex min-h-[320px] flex-col items-center justify-center rounded-2xl border border-dashed border-border/60 bg-muted/20 px-6 text-center">
+          <p className="font-semibold text-base">
+            {t("noAuthMethods", "No direct sign-in methods are available")}
+          </p>
+          <p className="mt-2 text-muted-foreground text-sm">
+            {t(
+              "noAuthMethodsDesc",
+              "Use the third-party sign-in options below, or contact support if this looks unexpected."
+            )}
+          </p>
+        </div>
+      );
+    }
+
+    if (AUTH_METHODS.length === 1) {
+      return AUTH_METHODS[0]?.children;
+    }
+
+    const defaultMethod = AUTH_METHODS[0];
+    if (!defaultMethod) return null;
+
+    return (
+      <Tabs defaultValue={defaultMethod.key}>
+        <TabsList className="mb-6 flex w-full *:flex-1">
+          {AUTH_METHODS.map((item) => (
+            <TabsTrigger key={item.key} value={item.key}>
+              {t(`methods.${item.key}`)}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {AUTH_METHODS.map((item) => (
+          <TabsContent key={item.key} value={item.key}>
+            {item.children}
+          </TabsContent>
+        ))}
+      </Tabs>
+    );
+  };
 
   return (
     <main className="flex h-full min-h-screen items-center bg-muted/50">
@@ -69,24 +132,7 @@ export default function Main() {
                     "Please login or register to continue"
                   )}
                 </div>
-                {AUTH_METHODS.length === 1
-                  ? AUTH_METHODS[0]?.children
-                  : AUTH_METHODS[0] && (
-                      <Tabs defaultValue={AUTH_METHODS[0].key}>
-                        <TabsList className="mb-6 flex w-full *:flex-1">
-                          {AUTH_METHODS.map((item) => (
-                            <TabsTrigger key={item.key} value={item.key}>
-                              {t(`methods.${item.key}`)}
-                            </TabsTrigger>
-                          ))}
-                        </TabsList>
-                        {AUTH_METHODS.map((item) => (
-                          <TabsContent key={item.key} value={item.key}>
-                            {item.children}
-                          </TabsContent>
-                        ))}
-                      </Tabs>
-                    )}
+                {renderAuthContent()}
               </div>
               <div className="py-8">
                 <OAuthMethods />

--- a/apps/user/src/sections/auth/oauth-methods.tsx
+++ b/apps/user/src/sections/auth/oauth-methods.tsx
@@ -4,20 +4,14 @@ import { Button } from "@workspace/ui/components/button";
 import { Icon } from "@workspace/ui/composed/icon";
 import { oAuthLogin } from "@workspace/ui/services/common/oauth";
 import { useGlobalStore } from "@/stores/global";
-
-const icons = {
-  apple: "uil:apple",
-  google: "logos:google-icon",
-  facebook: "logos:facebook",
-  github: "uil:github",
-  telegram: "logos:telegram",
-};
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 
 export function OAuthMethods() {
   const { common } = useGlobalStore();
   const { oauth_methods } = common;
   const OAUTH_METHODS = oauth_methods?.filter(
-    (method: string) => !["mobile", "email", "device"].includes(method)
+    (method: string) =>
+      !["mobile", "email", "device", "wechat", "weixin"].includes(method)
   );
   return (
     OAUTH_METHODS?.length > 0 && (
@@ -30,7 +24,7 @@ export function OAuthMethods() {
         <div className="mt-6 flex justify-center gap-4 *:size-12 *:p-2">
           {OAUTH_METHODS?.map((method: string) => (
             <Button
-              asChild
+              aria-label={getOAuthProviderMeta(method).label}
               key={method}
               onClick={async () => {
                 const { data } = await oAuthLogin({
@@ -47,7 +41,7 @@ export function OAuthMethods() {
               size="icon"
               variant="ghost"
             >
-              <Icon icon={icons[method as keyof typeof icons]} />
+              <Icon icon={getOAuthProviderMeta(method).icon} />
             </Button>
           ))}
         </div>

--- a/apps/user/src/sections/bind/index.tsx
+++ b/apps/user/src/sections/bind/index.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "@workspace/ui/components/spinner";
 import { Icon } from "@workspace/ui/composed/icon";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 import Certification from "./certification";
 
 export default function BindPage({
@@ -14,18 +15,19 @@ export default function BindPage({
   children?: ReactNode;
 }) {
   const { t } = useTranslation("auth");
+  const provider = getOAuthProviderMeta(platform);
 
   return (
     <Certification platform={platform}>
       <div className="relative flex h-screen w-full flex-col items-center justify-center overflow-hidden bg-background">
         <div className="flex animate-pulse flex-col items-center gap-4">
           <div className="flex items-center gap-3">
-            <Icon className="size-12" icon={`logos:${platform}`} />
+            <Icon className="size-12" icon={provider.icon} />
             <Spinner className="size-8" />
           </div>
           <div className="flex flex-col items-center gap-2">
             <h1 className="bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-500 bg-clip-text font-black text-transparent text-xl uppercase md:text-2xl dark:from-blue-400 dark:via-indigo-300 dark:to-violet-400">
-              {platform}
+              {provider.label}
             </h1>
             <p className="text-lg text-muted-foreground md:text-xl">
               {t("binding", "Binding account...")}

--- a/apps/user/src/sections/oauth/index.tsx
+++ b/apps/user/src/sections/oauth/index.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "@workspace/ui/components/spinner";
 import { Icon } from "@workspace/ui/composed/icon";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 import Certification from "./certification";
 
 export default function OAuthPage({
@@ -14,18 +15,19 @@ export default function OAuthPage({
   children?: ReactNode;
 }) {
   const { t } = useTranslation("auth");
+  const provider = getOAuthProviderMeta(platform);
 
   return (
     <Certification platform={platform}>
       <div className="relative flex h-screen w-full flex-col items-center justify-center overflow-hidden bg-background">
         <div className="flex animate-pulse flex-col items-center gap-4">
           <div className="flex items-center gap-3">
-            <Icon className="size-12" icon={`logos:${platform}`} />
+            <Icon className="size-12" icon={provider.icon} />
             <Spinner className="size-8" />
           </div>
           <div className="flex flex-col items-center gap-2">
             <h1 className="bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-500 bg-clip-text font-black text-transparent text-xl uppercase md:text-2xl dark:from-blue-400 dark:via-indigo-300 dark:to-violet-400">
-              {platform}
+              {provider.label}
             </h1>
             <p className="text-lg text-muted-foreground md:text-xl">
               {t("authenticating", "Authenticating...")}

--- a/apps/user/src/sections/user/profile/third-party-accounts.tsx
+++ b/apps/user/src/sections/user/profile/third-party-accounts.tsx
@@ -36,6 +36,7 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
+import { getOAuthProviderMeta } from "@/config/oauth-providers";
 import SendCode from "@/sections/auth/send-code";
 import { useGlobalStore } from "@/stores/global";
 
@@ -192,7 +193,7 @@ export default function ThirdPartyAccounts() {
     },
     {
       id: "telegram",
-      icon: "logos:telegram",
+      icon: getOAuthProviderMeta("telegram").icon,
       name: "Telegram",
       type: "OAuth",
       descriptionDefault: "Sign in with Telegram",
@@ -206,7 +207,7 @@ export default function ThirdPartyAccounts() {
     },
     {
       id: "google",
-      icon: "logos:google",
+      icon: getOAuthProviderMeta("google").icon,
       name: "Google",
       type: "OAuth",
       descriptionDefault: "Sign in with Google",

--- a/apps/user/src/stores/global.tsx
+++ b/apps/user/src/stores/global.tsx
@@ -4,8 +4,10 @@ import { create } from "zustand";
 
 export interface GlobalStore {
   common: API.GetGlobalConfigResponse;
+  commonReady: boolean;
   user?: API.User;
   setCommon: (common: Partial<API.GetGlobalConfigResponse>) => void;
+  setCommonReady: (ready: boolean) => void;
   setUser: (user?: API.User) => void;
   getUserInfo: () => Promise<void>;
   getUserSubscribe: (short: string, token: string, type?: string) => string[];
@@ -103,6 +105,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
     oauth_methods: [],
     web_ad: false,
   },
+  commonReady: false,
   user: undefined,
   setCommon: (common) =>
     set((state) => ({
@@ -111,6 +114,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
         ...common,
       },
     })),
+  setCommonReady: (commonReady) => set({ commonReady }),
   setUser: (user) => set({ user }),
   getUserInfo: async () => {
     try {

--- a/apps/user/src/stores/global.tsx
+++ b/apps/user/src/stores/global.tsx
@@ -118,7 +118,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
   setUser: (user) => set({ user }),
   getUserInfo: async () => {
     try {
-      const { data } = await queryUserInfo();
+      const { data } = await queryUserInfo({ skipErrorHandler: true });
       set({ user: data.data });
     } catch (error) {
       console.error("Failed to refresh user:", error);

--- a/apps/user/vite.config.ts
+++ b/apps/user/vite.config.ts
@@ -26,11 +26,16 @@ function versionLockPlugin(): Plugin {
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
+  const allowedHosts = [
+    "ppanel-dev.home.arpa",
+    "admin-ppanel-dev.home.arpa",
+  ];
+  const devtoolsPort = Number(env.VITE_DEVTOOLS_PORT || "42069");
 
   return {
     base: "./",
     plugins: [
-      devtools({ eventBusConfig: { port: 42_069 } }),
+      devtools({ eventBusConfig: { port: devtoolsPort } }),
       tanstackRouter({
         target: "react",
         autoCodeSplitting: true,
@@ -45,6 +50,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      allowedHosts,
       proxy: {
         "/api": {
           target: env.VITE_API_BASE_URL || "https://api.ppanel.dev",

--- a/apps/user/vite.config.ts
+++ b/apps/user/vite.config.ts
@@ -26,10 +26,13 @@ function versionLockPlugin(): Plugin {
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
-  const allowedHosts = [
-    "ppanel-dev.home.arpa",
-    "admin-ppanel-dev.home.arpa",
-  ];
+  // Dev server only: allow custom local domains such as Telepresence routes.
+  // Keep this env-driven so each developer can opt in without baking machine-specific hosts into source.
+  const allowedHosts = env.VITE_ALLOWED_HOSTS
+    ? env.VITE_ALLOWED_HOSTS.split(",")
+        .map((host) => host.trim())
+        .filter(Boolean)
+    : undefined;
   const devtoolsPort = Number(env.VITE_DEVTOOLS_PORT || "42069");
 
   return {

--- a/apps/user/vite.config.ts
+++ b/apps/user/vite.config.ts
@@ -1,23 +1,24 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { fileURLToPath, URL } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
 import { devtools } from "@tanstack/devtools-vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig, loadEnv, type Plugin } from "vite";
+import { resolveWebVersion } from "../../tools/resolve-web-version";
 
-// Plugin to generate version.lock file after build
+function resolveBuildVersion() {
+  const gitRoot = fileURLToPath(new URL("../../", import.meta.url));
+  return resolveWebVersion(gitRoot);
+}
+
 function versionLockPlugin(): Plugin {
   return {
     name: "version-lock",
     apply: "build",
     closeBundle() {
       const distDir = fileURLToPath(new URL("./dist", import.meta.url));
-      const rootPkgPath = fileURLToPath(
-        new URL("../../package.json", import.meta.url)
-      );
-      const rootPkg = JSON.parse(readFileSync(rootPkgPath, "utf-8"));
-      const version = rootPkg.version || "0.0.0";
+      const version = resolveBuildVersion();
       writeFileSync(`${distDir}/version.lock`, version);
     },
   };

--- a/apps/user/vite.config.ts
+++ b/apps/user/vite.config.ts
@@ -5,21 +5,20 @@ import { devtools } from "@tanstack/devtools-vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig, loadEnv, type Plugin } from "vite";
-import { resolveWebVersion } from "../../tools/resolve-web-version";
+import { resolveWebVersion } from "../../src/build/resolve-web-version";
 
-function resolveBuildVersion() {
-  const gitRoot = fileURLToPath(new URL("../../", import.meta.url));
-  return resolveWebVersion(gitRoot);
-}
-
-function versionLockPlugin(): Plugin {
+// Plugin to generate version metadata after build
+function versionMetadataPlugin(): Plugin {
   return {
-    name: "version-lock",
+    name: "version-metadata",
     apply: "build",
     closeBundle() {
       const distDir = fileURLToPath(new URL("./dist", import.meta.url));
-      const version = resolveBuildVersion();
-      writeFileSync(`${distDir}/version.lock`, version);
+      const version = resolveWebVersion();
+      writeFileSync(
+        `${distDir}/version.json`,
+        JSON.stringify(version, null, 2)
+      );
     },
   };
 }
@@ -27,17 +26,24 @@ function versionLockPlugin(): Plugin {
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
+  const webVersion = resolveWebVersion();
   // Dev server only: allow custom local domains such as Telepresence routes.
   // Keep this env-driven so each developer can opt in without baking machine-specific hosts into source.
-  const allowedHosts = env.VITE_ALLOWED_HOSTS
-    ? env.VITE_ALLOWED_HOSTS.split(",")
-        .map((host) => host.trim())
-        .filter(Boolean)
-    : undefined;
+  const allowedHosts = [
+    ".home.arpa",
+    ...(env.VITE_ALLOWED_HOSTS
+      ? env.VITE_ALLOWED_HOSTS.split(",")
+          .map((host) => host.trim())
+          .filter(Boolean)
+      : []),
+  ];
   const devtoolsPort = Number(env.VITE_DEVTOOLS_PORT || "42069");
 
   return {
     base: "./",
+    define: {
+      __APP_GIT_VERSION__: JSON.stringify(webVersion),
+    },
     plugins: [
       devtools({ eventBusConfig: { port: devtoolsPort } }),
       tanstackRouter({
@@ -46,7 +52,7 @@ export default defineConfig(({ mode }) => {
       }),
       viteReact(),
       tailwindcss(),
-      versionLockPlugin(),
+      versionMetadataPlugin(),
     ],
     resolve: {
       alias: {

--- a/docker/ppanel-admin-web/Dockerfile
+++ b/docker/ppanel-admin-web/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27-alpine
+
+COPY apps/admin/dist /usr/share/nginx/html

--- a/docker/ppanel-user-web/Dockerfile
+++ b/docker/ppanel-user-web/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27-alpine
+
+COPY apps/user/dist /usr/share/nginx/html

--- a/packages/ui/src/lib/request.ts
+++ b/packages/ui/src/lib/request.ts
@@ -4,6 +4,37 @@ import { isBrowser } from "@workspace/ui/utils/index";
 import axios, { type InternalAxiosRequestConfig } from "axios";
 import { toast } from "sonner";
 
+function normalizePath(value?: string) {
+  if (!value) return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+}
+
+function resolveBaseURL() {
+  const explicitBaseUrl = normalizePath(import.meta.env.VITE_API_BASE_URL);
+  if (explicitBaseUrl) return explicitBaseUrl;
+
+  const apiPrefix = normalizePath(import.meta.env.VITE_API_PREFIX);
+  if (apiPrefix?.startsWith("http://") || apiPrefix?.startsWith("https://")) {
+    return apiPrefix;
+  }
+
+  if (apiPrefix) return undefined;
+
+  const message =
+    "Missing API configuration: set VITE_API_BASE_URL or VITE_API_PREFIX before starting the app.";
+
+  if (isBrowser()) {
+    // Surface env mistakes clearly instead of silently guessing a fallback.
+    setTimeout(() => toast.error(message), 0);
+  }
+
+  throw new Error(message);
+}
+
 function handleError(response: {
   data?: { code?: number; message?: string };
   config?: { skipErrorHandler?: boolean };
@@ -173,7 +204,7 @@ function handleError(response: {
 }
 
 const request = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: resolveBaseURL(),
 });
 
 request.interceptors.request.use(

--- a/packages/ui/src/typings.d.ts
+++ b/packages/ui/src/typings.d.ts
@@ -9,6 +9,10 @@ declare global {
   }
 }
 
+interface ImportMetaEnv {
+  readonly VITE_APP_VERSION?: string;
+}
+
 // openapi2ts 生成的 request 参数里可能会包含 requestType（umi-request 风格）。
 // 我们的 request 基于 axios：这里做一个类型补丁，避免 TS 报错。
 declare module "axios" {

--- a/packages/ui/src/typings.d.ts
+++ b/packages/ui/src/typings.d.ts
@@ -7,6 +7,12 @@ declare global {
     logout: () => void;
     i18n: typeof i18n;
   }
+
+  const __APP_GIT_VERSION__: {
+    commit: string;
+    tag: string | null;
+    display_version: string;
+  };
 }
 
 interface ImportMetaEnv {

--- a/telepresence-kubeconfig-docker.example.json
+++ b/telepresence-kubeconfig-docker.example.json
@@ -1,0 +1,33 @@
+{
+  "kind": "Config",
+  "apiVersion": "v1",
+  "clusters": [
+    {
+      "name": "default",
+      "cluster": {
+        "server": "https://host.docker.internal:16443",
+        "insecure-skip-tls-verify": true
+      }
+    }
+  ],
+  "users": [
+    {
+      "name": "default",
+      "user": {
+        "client-certificate-data": "<base64-client-certificate-data>",
+        "client-key-data": "<base64-client-key-data>"
+      }
+    }
+  ],
+  "contexts": [
+    {
+      "name": "default",
+      "context": {
+        "cluster": "default",
+        "user": "default",
+        "namespace": "ppanel-dev"
+      }
+    }
+  ],
+  "current-context": "default"
+}

--- a/tools/resolve-web-version.ts
+++ b/tools/resolve-web-version.ts
@@ -16,17 +16,18 @@ export function resolveWebVersion(gitRoot: string) {
   }
 
   try {
-    const localTag = execSync(
-      "git tag --points-at HEAD --list 'v[0-9]*' | sort -V | tail -n 1",
-      {
-        cwd: gitRoot,
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "ignore"],
-        shell: "/bin/zsh",
-      }
-    ).trim();
+    const localTag = execSync("git tag --points-at HEAD --list 'v[0-9]*'", {
+      cwd: gitRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split("\n")
+      .map((tag) => tag.trim())
+      .filter(Boolean)
+      .sort((left, right) => left.localeCompare(right, undefined, { numeric: true }))
+      .at(-1);
 
-    if (localTag.match(RELEASE_TAG_PATTERN)) {
+    if (localTag?.match(RELEASE_TAG_PATTERN)) {
       return localTag;
     }
   } catch {

--- a/tools/resolve-web-version.ts
+++ b/tools/resolve-web-version.ts
@@ -1,0 +1,56 @@
+import { execSync } from "node:child_process";
+
+const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+(?:[-+].+)?$/;
+
+export function resolveWebVersion(gitRoot: string) {
+  const explicitVersion = process.env.PPANEL_WEB_VERSION?.trim();
+  if (explicitVersion) {
+    return explicitVersion;
+  }
+
+  const githubTag = process.env.GITHUB_REF_TYPE === "tag"
+    ? process.env.GITHUB_REF_NAME?.trim()
+    : undefined;
+  if (githubTag?.match(RELEASE_TAG_PATTERN)) {
+    return githubTag;
+  }
+
+  try {
+    const localTag = execSync(
+      "git tag --points-at HEAD --list 'v[0-9]*' | sort -V | tail -n 1",
+      {
+        cwd: gitRoot,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        shell: "/bin/zsh",
+      }
+    ).trim();
+
+    if (localTag.match(RELEASE_TAG_PATTERN)) {
+      return localTag;
+    }
+  } catch {
+    // Fall through to commit-based versioning when tags are unavailable.
+  }
+
+  const gitSha = process.env.GITHUB_SHA?.trim();
+  if (gitSha) {
+    return `sha-${gitSha.slice(0, 7)}`;
+  }
+
+  try {
+    const localGitSha = execSync("git rev-parse --short HEAD", {
+      cwd: gitRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    if (localGitSha) {
+      return `sha-${localGitSha}`;
+    }
+  } catch {
+    // Fall through to the default when git metadata is unavailable.
+  }
+
+  return "1.0.0";
+}


### PR DESCRIPTION
## What changed
- switched the admin and user root routes away from `react-helmet-async` for runtime title/meta updates and now sync `document.title` and basic head tags directly
- updated the admin and user build pipelines to emit structured `version.json` metadata and expose `__APP_GIT_VERSION__` to the frontend
- refreshed the system version card to read structured web version metadata and present clearer update actions
- allowed `.home.arpa` dev hosts by default in Vite so local admin domains like `admin-ppanel-dev.home.arpa` load without extra env configuration
- added the repository memory context file currently present on this branch

## Why
The browser tab title was stuck on `Loading...` because the app relied on `react-helmet-async`, while this repo is already on React 19 and the library only declares peer support through React 18. In practice, the root route state updated but `document.title` did not. At the same time, the branch also contains the version metadata changes and local host allowance changes the user asked to publish together.

## Impact
- browser tab titles now update correctly once site config loads
- frontend deployments now ship machine-readable web version metadata
- the dashboard version card can show the deployed web version from `version.json`
- local `.home.arpa` dev domains work without manual `VITE_ALLOWED_HOSTS` setup

## Validation
- `git diff --cached --check`
- `node node_modules/typescript/bin/tsc -p apps/admin/tsconfig.json --noEmit`
- `node node_modules/typescript/bin/tsc -p apps/user/tsconfig.json --noEmit`
