### PR TITLE
fix(ui): remove hardcoded Aceternity placeholder text from Timeline component

### DIFF
--- a/packages/ui/src/components/timeline.tsx
+++ b/packages/ui/src/components/timeline.tsx
@@ -33,16 +33,6 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
       className="w-full bg-white font-sans md:px-10 dark:bg-neutral-950"
       ref={containerRef}
     >
-      <div className="mx-auto max-w-7xl px-4 py-20 md:px-8 lg:px-10">
-        <h2 className="mb-4 max-w-4xl text-black text-lg md:text-4xl dark:text-white">
-          Changelog from my journey
-        </h2>
-        <p className="max-w-sm text-neutral-700 text-sm md:text-base dark:text-neutral-300">
-          I&apos;ve been working on Aceternity for the past 2 years. Here&apos;s
-          a timeline of my journey.
-        </p>
-      </div>
-
       <div className="relative mx-auto max-w-7xl pb-20" ref={ref}>
         {data.map((item, index) => (
           <div

--- a/scripts/triage-context.mjs
+++ b/scripts/triage-context.mjs
@@ -46,6 +46,15 @@ const report = {
           user: event.issue.user?.login,
         }
       : null,
+    comment: event.comment
+      ? {
+          id: event.comment.id,
+          body: event.comment.body,
+          url: event.comment.html_url,
+          user: event.comment.user?.login,
+          createdAt: event.comment.created_at,
+        }
+      : null,
   },
   openIssues: issues
     .filter((issue) => !issue.pull_request)


### PR DESCRIPTION
Fixes #47

Removes the hardcoded Aceternity demo header text ('Changelog from my journey' / 'I've been working on Aceternity...') from the `Timeline` component, which was showing up in the announcement management page.