### PR TITLE
fix(nodes): reset edit form with initial values on open

### DIFF
--- a/apps/admin/src/sections/nodes/node-form.tsx
+++ b/apps/admin/src/sections/nodes/node-form.tsx
@@ -246,7 +246,15 @@ export default function NodeForm(props: {
       <SheetTrigger asChild>
         <Button
           onClick={() => {
-            form.reset();
+            form.reset({
+              name: "",
+              server_id: undefined,
+              protocol: "",
+              address: "",
+              port: 0,
+              tags: [],
+              ...normalizeValues(initialValues),
+            });
             setAutoFilledFields(new Set());
           }}
         >

--- a/apps/admin/src/sections/nodes/node-form.tsx
+++ b/apps/admin/src/sections/nodes/node-form.tsx
@@ -70,10 +70,15 @@ const buildSchema = (t: TFunction) =>
       .int()
       .min(1, t("errors.portRange", "Port must be between 1 and 65535"))
       .max(65_535, t("errors.portRange", "Port must be between 1 and 65535")),
-    tags: z.array(z.string()),
+    tags: z.preprocess((v) => (Array.isArray(v) ? v : []), z.array(z.string())),
   });
 
 export type NodeFormValues = z.infer<ReturnType<typeof buildSchema>>;
+
+function normalizeValues(v?: Partial<NodeFormValues>): Partial<NodeFormValues> {
+  if (!v) return {};
+  return { ...v, tags: Array.isArray(v.tags) ? v.tags : [] };
+}
 
 export default function NodeForm(props: {
   trigger: string;
@@ -112,7 +117,7 @@ export default function NodeForm(props: {
       address: "",
       port: 0,
       tags: [],
-      ...initialValues,
+      ...normalizeValues(initialValues),
     },
   });
 
@@ -134,7 +139,7 @@ export default function NodeForm(props: {
         address: "",
         port: 0,
         tags: [],
-        ...initialValues,
+        ...normalizeValues(initialValues),
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Problem

When clicking the Edit button on a node, `form.reset()` was called with no arguments, clearing all fields to their default values (empty strings, `port: 0`, etc.). Since `initialValues` (the row reference) did not change, the `useEffect` that repopulates the form from `initialValues` never re-fired — so the edit sheet opened with a blank form.

Submitting the blank form triggered Zod validation errors, shown as **"Invalid input"** toasts.

## Fix

Pass the normalized `initialValues` into `form.reset()` on trigger click, so the edit sheet always opens pre-filled with the current node data.

Closes #51