### PR TITLE
fix: show error toast on auth form submission failure

### DIFF
--- a/apps/admin/src/sections/auth/email/auth-form.tsx
+++ b/apps/admin/src/sections/auth/email/auth-form.tsx
@@ -59,8 +59,8 @@ export default function EmailAuthForm() {
             setType("login");
             break;
         }
-      } catch (_error) {
-        /* empty */
+      } catch (error: any) {
+        toast.error(error?.response?.data?.message || error?.message || "An error occurred");
       }
     });
   };

--- a/apps/user/src/sections/auth/email/auth-form.tsx
+++ b/apps/user/src/sections/auth/email/auth-form.tsx
@@ -68,8 +68,8 @@ export default function EmailAuthForm() {
             setType("login");
             break;
         }
-      } catch (_error) {
-        /* empty */
+      } catch (error: any) {
+        toast.error(error?.response?.data?.message || error?.message || "An error occurred");
       }
     });
   };

--- a/apps/user/src/sections/auth/phone/auth-form.tsx
+++ b/apps/user/src/sections/auth/phone/auth-form.tsx
@@ -68,8 +68,8 @@ export default function PhoneAuthForm() {
             setType("login");
             break;
         }
-      } catch (_error) {
-        /* empty */
+      } catch (error: any) {
+        toast.error(error?.response?.data?.message || error?.message || "An error occurred");
       }
     });
   };


### PR DESCRIPTION
## Problem

Silent `catch` blocks in auth forms caused zero user feedback when API calls failed during reset/login/register flows. This directly caused the behavior reported in #57 — clicking Reset Password with no visible response.

## Changes

- `apps/user/src/sections/auth/email/auth-form.tsx` — replace empty catch with `toast.error()`
- `apps/user/src/sections/auth/phone/auth-form.tsx` — same fix
- `apps/admin/src/sections/auth/email/auth-form.tsx` — same fix

## Closes

Fixes #57