### PR TITLE
fix(servers): disable query retry on node config load error

### DIFF
--- a/apps/admin/src/sections/servers/server-node-config.tsx
+++ b/apps/admin/src/sections/servers/server-node-config.tsx
@@ -115,13 +115,18 @@ export default function ServerNodeConfig({ server }: { server: API.Server }) {
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  const { data: cfgResp, refetch } = useQuery({
+  const {
+    data: cfgResp,
+    refetch,
+    isError,
+  } = useQuery({
     queryKey: ["getServerNodeConfig", server.id],
     queryFn: async () => {
       const { data } = await getServerNodeConfig({ server_id: server.id });
       return data.data;
     },
     enabled: open,
+    retry: false,
   });
 
   const form = useForm<ServerNodeConfigFormData>({
@@ -206,6 +211,14 @@ export default function ServerNodeConfig({ server }: { server: API.Server }) {
         </SheetHeader>
 
         <ScrollArea className="h-[calc(100vh-8rem)] pr-3">
+          {isError && (
+            <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-destructive text-sm">
+              {t(
+                "server_node_config.loadError",
+                "Failed to load node config. Please close and try again."
+              )}
+            </div>
+          )}
           <Tabs className="mt-4" defaultValue="dns">
             <TabsList className="grid w-full grid-cols-3">
               <TabsTrigger value="dns">


### PR DESCRIPTION
Fixes #61 — repeated system error toasts when opening Node Config panel.

Root cause: React Query default 3 retries × global toast.error in axios interceptor = 3-4 toasts per failure.

Fix: retry: false on useQuery + inline error banner in the sheet.