### PR TITLE
feat(subscribe): admin toggle to show/hide the user tutorial section

### DIFF
--- a/apps/admin/public/assets/locales/en-US/subscribe.json
+++ b/apps/admin/public/assets/locales/en-US/subscribe.json
@@ -24,6 +24,8 @@
     "description": "Manage subscription system settings",
     "singleSubscriptionMode": "Single Subscription Mode",
     "singleSubscriptionModeDescription": "Limit users to one active subscription. Existing subscriptions unaffected",
+    "showTutorial": "Show Tutorial Section",
+    "showTutorialDescription": "Show the client tutorial section on the user document page",
     "subscriptionDomain": "Subscription Domain",
     "subscriptionDomainDescription": "Custom domain for subscription links",
     "subscriptionDomainPlaceholder": "Enter subscription domain, one per line",

--- a/apps/admin/public/assets/locales/zh-CN/subscribe.json
+++ b/apps/admin/public/assets/locales/zh-CN/subscribe.json
@@ -22,6 +22,8 @@
     "description": "管理订阅系统设置",
     "singleSubscriptionMode": "单一订阅模式",
     "singleSubscriptionModeDescription": "限制用户只能有一个活跃订阅。现有订阅不受影响",
+    "showTutorial": "显示教程板块",
+    "showTutorialDescription": "在用户文档页显示客户端教程板块",
     "subscriptionDomain": "订阅域名",
     "subscriptionDomainDescription": "订阅链接的自定义域名",
     "subscriptionDomainPlaceholder": "输入订阅域名，每行一个",

--- a/apps/admin/src/sections/subscribe/config-form.tsx
+++ b/apps/admin/src/sections/subscribe/config-form.tsx
@@ -42,6 +42,7 @@ const subscribeConfigSchema = z.object({
   subscribe_domain: z.string().optional(),
   user_agent_limit: z.boolean().optional(),
   user_agent_list: z.string().optional(),
+  show_tutorial: z.boolean().optional(),
 });
 
 type SubscribeConfigFormData = z.infer<typeof subscribeConfigSchema>;
@@ -69,6 +70,7 @@ export default function ConfigForm() {
       subscribe_domain: "",
       user_agent_limit: false,
       user_agent_list: "",
+      show_tutorial: true,
     },
   });
 
@@ -125,6 +127,31 @@ export default function ConfigForm() {
               id="subscribe-config-form"
               onSubmit={form.handleSubmit(onSubmit)}
             >
+              <FormField
+                control={form.control}
+                name="show_tutorial"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("config.showTutorial", "Show Tutorial Section")}
+                    </FormLabel>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        className="!mt-0 float-end"
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {t(
+                        "config.showTutorialDescription",
+                        "Show the client tutorial section on the user document page"
+                      )}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
               <FormField
                 control={form.control}
                 name="single_model"

--- a/apps/user/src/sections/user/document/index.tsx
+++ b/apps/user/src/sections/user/document/index.tsx
@@ -10,14 +10,15 @@ import {
 import Empty from "@workspace/ui/composed/empty";
 import { queryDocumentList } from "@workspace/ui/services/user/document";
 import { useTranslation } from "react-i18next";
-import { TUTORIAL_DOCUMENT } from "@/config";
 import { DocumentButton } from "@/sections/user/document/document-button";
 import { getTutorialList } from "@/sections/user/document/tutorial";
 import { TutorialButton } from "@/sections/user/document/tutorial-button";
+import { useGlobalStore } from "@/stores/global";
 
 export default function Document() {
   const { t, i18n } = useTranslation("document");
   const locale = i18n.language;
+  const { common } = useGlobalStore();
 
   const { data } = useQuery({
     queryKey: ["queryDocumentList"],
@@ -42,7 +43,7 @@ export default function Document() {
       const list = await getTutorialList();
       return list.get(locale);
     },
-    enabled: TUTORIAL_DOCUMENT === "true",
+    enabled: common.subscribe?.show_tutorial !== false,
   });
 
   if (

--- a/packages/ui/src/services/admin/typings.d.ts
+++ b/packages/ui/src/services/admin/typings.d.ts
@@ -2115,6 +2115,7 @@ declare namespace API {
     pan_domain: boolean;
     user_agent_limit: boolean;
     user_agent_list: string;
+    show_tutorial?: boolean;
   };
 
   type SubscribeDiscount = {

--- a/packages/ui/src/services/common/typings.d.ts
+++ b/packages/ui/src/services/common/typings.d.ts
@@ -912,6 +912,7 @@ declare namespace API {
     pan_domain: boolean;
     user_agent_limit: boolean;
     user_agent_list: string;
+    show_tutorial?: boolean;
   };
 
   type SubscribeDiscount = {

--- a/packages/ui/src/services/user/typings.d.ts
+++ b/packages/ui/src/services/user/typings.d.ts
@@ -1020,6 +1020,7 @@ declare namespace API {
     pan_domain: boolean;
     user_agent_limit: boolean;
     user_agent_list: string;
+    show_tutorial?: boolean;
   };
 
   type SubscribeDiscount = {


### PR DESCRIPTION
## Purpose

The user document page's **tutorial** section is currently gated only by the build-time `VITE_TUTORIAL_DOCUMENT` env var, so operators can't hide it without rebuilding the frontend. This turns it into a runtime, admin-editable setting.

## Changes

- **Admin** (`subscribe/config-form.tsx`): add a *Show Tutorial Section* switch to the existing subscribe config form. Since that form round-trips the whole `SubscribeConfig`, the new field is added to its zod schema/defaults so it isn't stripped on save.
- **User** (`user/document/index.tsx`): gate the tutorial section on `common.subscribe.show_tutorial` (from the global config store) instead of the build-time `VITE_TUTORIAL_DOCUMENT`. Defaults to shown when unset.
- **Types**: add optional `show_tutorial` to `SubscribeConfig` (admin/user/common typings).
- **i18n**: en-US / zh-CN strings for the new switch.

## Dependency

Requires **perfect-panel/server#151**, which adds the `ShowTutorial` field to the subscribe config and seeds the default (`true`) so existing installs keep showing tutorials.

## Scope

Only the show/hide toggle. Custom/private tutorial repos are intentionally out of scope.

## Note

I couldn't run a local build for this PR; please let CI typecheck. Changes are localized and follow the existing subscribe-config pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)