### PR TITLE
feat(email): add Reply-To field to SMTP settings

### DIFF
--- a/apps/admin/public/assets/locales/en-US/auth-control.json
+++ b/apps/admin/public/assets/locales/en-US/auth-control.json
@@ -53,6 +53,8 @@
     "maintenanceTemplate": "Maintenance Template",
     "senderAddress": "Sender Address",
     "senderAddressDescription": "The email address that appears in the From field",
+    "replyToAddress": "Reply-To Address",
+    "replyToAddressDescription": "Optional. Where user replies go. Keep the From address on a verified/aligned domain (SPF/DKIM) for deliverability and put your real reply inbox here.",
     "sendFailure": "Email send failed",
     "sendSuccess": "Email sent successfully",
     "sendTestEmail": "Send Test Email",

--- a/apps/admin/public/assets/locales/zh-CN/auth-control.json
+++ b/apps/admin/public/assets/locales/zh-CN/auth-control.json
@@ -53,6 +53,8 @@
     "maintenanceTemplate": "维护模板",
     "senderAddress": "发件人地址",
     "senderAddressDescription": "显示在发件人字段中的邮箱地址",
+    "replyToAddress": "回复地址 (Reply-To)",
+    "replyToAddressDescription": "可选。用户回复邮件时的收件地址。发件人(From)请保持在已验证/对齐的域名上(SPF/DKIM)以保证送达,把真正接收回复的邮箱填在这里。",
     "sendFailure": "邮件发送失败",
     "sendSuccess": "邮件发送成功",
     "sendTestEmail": "发送测试邮件",

--- a/apps/admin/src/sections/auth-control/forms/email-settings-form.tsx
+++ b/apps/admin/src/sections/auth-control/forms/email-settings-form.tsx
@@ -63,6 +63,7 @@ const emailSettingsSchema = z.object({
           user: z.string().optional(),
           pass: z.string().optional(),
           from: z.string().optional(),
+          reply_to: z.string().optional(),
         })
         .optional(),
     })
@@ -110,6 +111,7 @@ export default function EmailSettingsForm() {
           user: "",
           pass: "",
           from: "",
+          reply_to: "",
         },
       },
     },
@@ -477,6 +479,35 @@ export default function EmailSettingsForm() {
                           {t(
                             "email.senderAddressDescription",
                             "The email address that appears in the From field"
+                          )}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="config.platform_config.reply_to"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {t("email.replyToAddress", "Reply-To Address")}
+                        </FormLabel>
+                        <FormControl>
+                          <EnhancedInput
+                            onValueChange={field.onChange}
+                            placeholder={t(
+                              "email.inputPlaceholder",
+                              "Please enter"
+                            )}
+                            value={field.value}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t(
+                            "email.replyToAddressDescription",
+                            "Optional. Where user replies go. Keep the From address on a verified/aligned domain (SPF/DKIM) for deliverability and put your real reply inbox here."
                           )}
                         </FormDescription>
                         <FormMessage />


### PR DESCRIPTION
## Problem

The email SMTP settings only expose a *Sender Address* (`from`). For deliverability the From should sit on a verified, SPF/DKIM-aligned domain (e.g. a Mailgun sending domain), but operators often want **replies** to go to a different inbox. Without a Reply-To field, the only option is to send From the reply address — which breaks alignment and often lands in spam.

## Change

- Adds an optional **Reply-To Address** input to the SMTP settings tab (under *Sender Address*).
- `platform_config` schema + defaults: new optional `reply_to`.
- en-US / zh-CN strings.

The value is saved into the existing `platform_config` JSON, so the server reads it via the new `reply_to` field (see companion PR).

## Dependency

Requires **perfect-panel/server#159**, which adds the `reply_to` field to `smtp.Config` and sets the `Reply-To` header when non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)