### PR TITLE
fix(user): restore deeplink detection logic in import button

### DIFF
--- a/apps/user/src/sections/user/dashboard/content.tsx
+++ b/apps/user/src/sections/user/dashboard/content.tsx
@@ -453,6 +453,18 @@ export default function Content() {
                                         url,
                                         application.scheme
                                       );
+
+                                      // Check if the generated link is a plain HTTP/HTTPS URL
+                                      // If so, only copy to clipboard without triggering redirect
+                                      const isPlainHttpUrl = /^https?:/; //i.test(href);
+
+                                      if (isPlainHttpUrl) {
+                                        toast.success(
+                                          t("copySuccess", "Copy Success")
+                                        );
+                                        return;
+                                      }
+
                                       const showSuccessMessage = () => {
                                         toast.success(
                                           <>

--- a/apps/user/src/sections/user/dashboard/content.tsx
+++ b/apps/user/src/sections/user/dashboard/content.tsx
@@ -456,7 +456,7 @@ export default function Content() {
 
                                       // Check if the generated link is a plain HTTP/HTTPS URL
                                       // If so, only copy to clipboard without triggering redirect
-                                      const isPlainHttpUrl = /^https?:/; //i.test(href);
+                                      const isPlainHttpUrl = /^https?:/i.test(href);
 
                                       if (isPlainHttpUrl) {
                                         toast.success(


### PR DESCRIPTION
Fix typo in regex test that caused `isPlainHttpUrl` to always be truthy.

This regression (introduced in v1.7.4) broke all app deeplinks (`clash://`, `shadowrocket://`, etc) — they only triggered clipboard copy and never launched the apps.

**Root cause:** `.test(href)` was commented out, leaving `isPlainHttpUrl` assigned to a regex object (always truthy).

**Fix:** Restore the complete test: `/^https?:/i.test(href)`

Closes #83