### PR TITLE
fix(user): detect HTTP scheme and prevent redirect for plain web links

### DIFF
--- a/apps/user/public/assets/locales/zh-CN/dashboard.json
+++ b/apps/user/public/assets/locales/zh-CN/dashboard.json
@@ -11,6 +11,7 @@
   "expired": "已过期",
   "finished": "已完成",
   "import": "一键导入",
+  "clickToCopy": "点击复制",
   "latestAnnouncement": "最新公告",
   "manualImportMessage": "请手动导入",
   "mySubscriptions": "我的订阅",

--- a/apps/user/src/sections/user/dashboard/content.tsx
+++ b/apps/user/src/sections/user/dashboard/content.tsx
@@ -444,6 +444,10 @@ export default function Content() {
                                   const downloadUrl =
                                     application.download_link?.[platform];
 
+                                  const isHttpLink =
+                                    application.scheme?.startsWith("http://") ||
+                                    application.scheme?.startsWith("https://");
+
                                   const handleCopy = (
                                     _: string,
                                     result: boolean
@@ -470,7 +474,7 @@ export default function Content() {
                                         );
                                       };
 
-                                      if (isBrowser() && href) {
+                                      if (isBrowser() && href && !isHttpLink) {
                                         window.location.href = href;
                                         const checkRedirect = setTimeout(() => {
                                           if (window.location.href !== href) {
@@ -539,7 +543,12 @@ export default function Content() {
                                               }
                                               size="sm"
                                             >
-                                              {t("import", "Import")}
+                                              {isHttpLink
+                                                ? t(
+                                                    "clickToCopy",
+                                                    "Click to Copy"
+                                                  )
+                                                : t("import", "Import")}
                                             </Button>
                                           </CopyToClipboard>
                                         )}


### PR DESCRIPTION
Fixes #82

Changes:
- Add clickToCopy locale for button text when subscription link is HTTP/HTTPS
- Detect if application.scheme starts with http:// or https://
- When isHttpLink=true, skip window.location.href redirect (only copy to clipboard)
- Change button text from Import to Click to Copy for HTTP links

Implementation follows the suggested approach in issue comment 4685724509