### PR TITLE
fix(dashboard): correctly detect http(s):// links and disable deep link trigger

### DIFF
--- a/apps/user/public/assets/locales/zh-CN/dashboard.json
+++ b/apps/user/public/assets/locales/zh-CN/dashboard.json
@@ -11,6 +11,7 @@
   "expired": "已过期",
   "finished": "已完成",
   "import": "一键导入",
+  "clickToCopy": "点击复制",
   "latestAnnouncement": "最新公告",
   "manualImportMessage": "请手动导入",
   "mySubscriptions": "我的订阅",

--- a/apps/user/src/sections/user/dashboard/content.tsx
+++ b/apps/user/src/sections/user/dashboard/content.tsx
@@ -444,6 +444,11 @@ export default function Content() {
                                   const downloadUrl =
                                     application.download_link?.[platform];
 
+                                  // Check if scheme template outputs the raw URL (which would be http(s)://)
+                                  // rather than the scheme prefix itself
+                                  const isHttpLink =
+                                    application.scheme?.startsWith("${url}");
+
                                   const handleCopy = (
                                     _: string,
                                     result: boolean
@@ -470,7 +475,7 @@ export default function Content() {
                                         );
                                       };
 
-                                      if (isBrowser() && href) {
+                                      if (isBrowser() && href && !isHttpLink) {
                                         window.location.href = href;
                                         const checkRedirect = setTimeout(() => {
                                           if (window.location.href !== href) {
@@ -539,7 +544,12 @@ export default function Content() {
                                               }
                                               size="sm"
                                             >
-                                              {t("import", "Import")}
+                                              {isHttpLink
+                                                ? t(
+                                                    "clickToCopy",
+                                                    "Click to Copy"
+                                                  )
+                                                : t("import", "Import")}
                                             </Button>
                                           </CopyToClipboard>
                                         )}


### PR DESCRIPTION
## Description

Fixes the http(s):// link detection issue where the 'Import' button was still trying to trigger deep links for raw URLs.

## Changes

- Check if scheme template starts with `${url}` (indicates raw URL mode)
- When `isHttpLink=true`, skip `window.location.href` deep link trigger
- Change button text from 'Import' to 'Click to Copy' for http links
- Add zh-CN translation for 'clickToCopy'

## Related Issues

Closes #82
Closes #83