### PR TITLE
fix(dashboard): redirect online users stat to servers page

### DIFF
--- a/apps/admin/src/sections/dashboard/components/statistics.tsx
+++ b/apps/admin/src/sections/dashboard/components/statistics.tsx
@@ -202,7 +202,7 @@ export default function Statistics() {
             value: ServerTotal?.online_users || 0,
             subtitle: t("currentlyOnline", "Currently Online"),
             icon: "uil:users-alt",
-            href: "/dashboard/user",
+            href: "/dashboard/servers",
             color: "text-blue-600 dark:text-blue-400",
             iconBg: "bg-blue-100 dark:bg-blue-900/30",
           },


### PR DESCRIPTION
## Description

Fixes the redirect target for the 'Online Users' statistics card on the admin dashboard.

## Problem

The 'Online Users' card was redirecting to `/dashboard/user` (user management page), which doesn't display online user information or provide any filtering for online status.

## Solution

Changed the redirect to `/dashboard/servers`, where online users are actually displayed in the server list (each server shows its online users count and details).

## Related Issues

Closes #86