### PR TITLE
fix: redirect online users card to servers page

### DIFF
--- a/apps/admin/src/sections/dashboard/components/statistics.tsx
+++ b/apps/admin/src/sections/dashboard/components/statistics.tsx
@@ -202,7 +202,7 @@ export default function Statistics() {
             value: ServerTotal?.online_users || 0,
             subtitle: t("currentlyOnline", "Currently Online"),
             icon: "uil:users-alt",
-            href: "/dashboard/user",
+            href: "/dashboard/servers",
             color: "text-blue-600 dark:text-blue-400",
             iconBg: "bg-blue-100 dark:bg-blue-900/30",
           },


### PR DESCRIPTION
## Description

Fixes #86 

The 'Online Users' count card in the admin dashboard was incorrectly linked to `/dashboard/user` (User Management page), which doesn't display online status information. 

This PR changes the link to `/dashboard/servers` where online user information is actually available.

## Changes
- Updated the `href` property of the 'Online Users' card from `/dashboard/user` to `/dashboard/servers`

## Testing
- [ ] Verify clicking 'Online Users' card now navigates to the Servers Management page
- [ ] Confirm online user information is visible on the target page