### PR TITLE
fix: remove duplicate show_original_price field and deduplicate duration options

### DIFF
--- a/apps/admin/src/sections/product/subscribe-form.tsx
+++ b/apps/admin/src/sections/product/subscribe-form.tsx
@@ -900,33 +900,6 @@ export default function SubscribeForm<T extends Record<string, any>>({
                         </FormItem>
                       )}
                     />
-                    <FormField
-                      control={form.control}
-                      name="show_original_price"
-                      render={({ field }) => (
-                        <FormItem>
-                          <div className="flex items-center justify-between">
-                            <div className="space-y-0.5">
-                              <FormLabel>
-                                {t("form.showOriginalPrice")}
-                              </FormLabel>
-                              <FormDescription>
-                                {t("form.showOriginalPriceDescription")}
-                              </FormDescription>
-                            </div>
-                            <FormControl>
-                              <Switch
-                                checked={!!field.value}
-                                onCheckedChange={(value) => {
-                                  form.setValue(field.name, value);
-                                }}
-                              />
-                            </FormControl>
-                          </div>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
                   </div>
                 </TabsContent>
 

--- a/apps/user/src/sections/subscribe/duration-selector.tsx
+++ b/apps/user/src/sections/subscribe/duration-selector.tsx
@@ -53,6 +53,8 @@ const DurationSelector: React.FC<DurationSelectorProps> = ({
   )?.discount;
   const discountPercentage = currentDiscount ? 100 - currentDiscount : 0;
 
+  const hasQuantityOne = discounts?.some((item) => item.quantity === 1);
+
   return (
     <>
       <div className="font-semibold">
@@ -63,7 +65,7 @@ const DurationSelector: React.FC<DurationSelectorProps> = ({
         onValueChange={handleChange}
         value={String(quantity)}
       >
-        {showOriginalPrice && unitTime !== "Minute" && (
+        {showOriginalPrice && unitTime !== "Minute" && !hasQuantityOne && (
           <DurationOption label={`1 / ${t(unitTime)}`} value="1" />
         )}
         {discounts?.map((item) => (


### PR DESCRIPTION
## 🐛 Bug Fixes

This PR addresses two UI duplication bugs reported in #93:

### Bug 1: Duplicate 'Show Original Price' field in subscription form
- **File**: `apps/admin/src/sections/product/subscribe-form.tsx`
- **Issue**: The `show_original_price` FormField was rendered twice (lines 844 and 905)
- **Fix**: Removed the duplicate field at line 905

### Bug 2: Duplicate '1 / Month' option in purchase duration selector
- **File**: `apps/user/src/sections/subscribe/duration-selector.tsx`
- **Issue**: When discounts contain a `quantity: 1` entry, the duration selector would render two '1 / Month' options — one hardcoded base option and one from the discounts map
- **Fix**: Added logic to skip rendering the hardcoded base option when `quantity: 1` already exists in discounts array

## 🧪 Testing
- Verified that `show_original_price` now appears only once in the subscription form
- Confirmed that duration selector properly deduplicates options when discounts contain `quantity: 1`

Fixes #93