### PR TITLE
fix: remove invalid favicon mime type

### DIFF
--- a/apps/admin/src/routes/__root.tsx
+++ b/apps/admin/src/routes/__root.tsx
@@ -50,7 +50,7 @@ export const Route = createRootRouteWithContext()({
           <meta content={description} name="description" />
           <meta content={keywords} name="keywords" />
           <link href={url} rel="canonical" />
-          <link href={logo} rel="icon" type="image/*" />
+          <link href={logo} rel="icon" />
           <link href={logo} rel="apple-touch-icon" sizes="180x180" />
           <link href="/site.webmanifest" rel="manifest" />
         </Helmet>

--- a/apps/user/src/routes/__root.tsx
+++ b/apps/user/src/routes/__root.tsx
@@ -53,7 +53,7 @@ export const Route = createRootRouteWithContext()({
           <meta content={description} name="description" />
           <meta content={keywords} name="keywords" />
           <link href={url} rel="canonical" />
-          <link href={logo} rel="icon" type="image/*" />
+          <link href={logo} rel="icon" />
           <link href={logo} rel="apple-touch-icon" sizes="180x180" />
           <link href="/site.webmanifest" rel="manifest" />
         </Helmet>


### PR DESCRIPTION
## Summary
- remove the invalid `type="image/*"` attribute from dynamic favicon links in admin and user roots
- let browsers infer the icon MIME type from the resource

Fixes #101

## Verification
- `bun x biome check apps/user/src/routes/__root.tsx apps/admin/src/routes/__root.tsx`
- `bun run check` (fails on pre-existing `packages/ui/src/composed/markdown.tsx` sorted attributes issue)