### PR TITLE
fix(user): keep tutorial hidden when show_tutorial is disabled

### DIFF
--- a/apps/user/src/sections/user/document/index.tsx
+++ b/apps/user/src/sections/user/document/index.tsx
@@ -19,6 +19,7 @@ export default function Document() {
   const { t, i18n } = useTranslation("document");
   const locale = i18n.language;
   const { common } = useGlobalStore();
+  const showTutorial = common.subscribe?.show_tutorial !== false;
 
   const { data } = useQuery({
     queryKey: ["queryDocumentList"],
@@ -43,7 +44,7 @@ export default function Document() {
       const list = await getTutorialList();
       return list.get(locale);
     },
-    enabled: common.subscribe?.show_tutorial !== false,
+    enabled: showTutorial,
   });
 
   if (
@@ -85,7 +86,7 @@ export default function Document() {
         </>
       )}
 
-      {TutorialList && TutorialList?.length > 0 && (
+      {showTutorial && TutorialList && TutorialList?.length > 0 && (
         <>
           <h2 className="flex items-center gap-1.5 font-semibold">
             {t("tutorial", "Tutorial")}

--- a/apps/user/src/stores/global.tsx
+++ b/apps/user/src/stores/global.tsx
@@ -96,6 +96,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => ({
       pan_domain: false,
       user_agent_limit: false,
       user_agent_list: "",
+      show_tutorial: false,
     },
     verify_code: {
       verify_code_expire_time: 5,


### PR DESCRIPTION
## Summary

Closes #104.

The User Web **Document** page keeps rendering the Tutorial section even after an admin sets `subscribe.show_tutorial = false`. It's reproducible, not a flaky race.

## Root cause

1. The global store's initial `subscribe` state (`apps/user/src/stores/global.tsx`) has no `show_tutorial` field, so on first render `common.subscribe?.show_tutorial !== false` is `undefined !== false === true`.
2. `getGlobalConfig()` loads asynchronously in `__root.tsx`, so on the first render the config hasn't arrived yet — the tutorial query (`enabled: show_tutorial !== false`) fires immediately.
3. Once that query resolves, React Query caches the list. Flipping `enabled` to `false` afterwards stops *future* fetches but keeps the already-cached data.
4. The render gate only checked `TutorialList?.length > 0`, ignoring `show_tutorial` — so the section renders regardless of the setting.

## Fix

- **`stores/global.tsx`** — add `show_tutorial: false` to the initial `subscribe` state, so the query stays disabled on the first render until config loads. (The type already allows it: `subscribe.show_tutorial?: boolean`.)
- **`sections/user/document/index.tsx`** — extract a `showTutorial` flag and also gate the tutorial section's render on it, not only on the fetched list length. Defense in depth so cached data can never surface the section while it's disabled.

Either change alone fixes the reported issue; together they also close the cached-data path.

## Testing

- Tutorial disabled (`show_tutorial = false`) → Document page no longer renders the Tutorial section (query never fires, and the render is gated).
- Tutorial enabled → tutorial loads and renders as before.
- Both document and tutorial empty → the existing `<Empty />` state still shows.
