### PR TITLE
fix: copy subscription URL on app import

### DIFF
--- a/apps/user/src/sections/user/dashboard/content.tsx
+++ b/apps/user/src/sections/user/dashboard/content.tsx
@@ -545,10 +545,7 @@ export default function Content() {
                                         {application.scheme && (
                                           <CopyToClipboard
                                             onCopy={handleCopy}
-                                            text={getAppSubLink(
-                                              url,
-                                              application.scheme
-                                            )}
+                                            text={url}
                                           >
                                             <Button
                                               className={


### PR DESCRIPTION
## Summary
- Copy the raw subscription URL when using app import buttons
- Keep the generated app scheme only for launching the client

Fixes #111

## Checks
- bun run lint
- bun run check