### PR TITLE
fix: load admin store lookup data by pages

### DIFF
--- a/apps/admin/src/stores/node.ts
+++ b/apps/admin/src/stores/node.ts
@@ -3,6 +3,7 @@ import {
   queryNodeTag,
 } from "@workspace/ui/services/admin/server";
 import { create } from "zustand";
+import { fetchAllPaginated } from "./pagination";
 
 interface NodeState {
   // Data
@@ -44,9 +45,9 @@ export const useNodeStore = create<NodeState>((set, get) => ({
 
     set({ loading: true });
     try {
-      const { data } = await filterNodeList({ page: 1, size: 999_999_999 });
+      const nodes = await fetchAllPaginated(filterNodeList);
       set({
-        nodes: data?.data?.list || [],
+        nodes,
         loaded: true,
       });
     } catch (_error) {

--- a/apps/admin/src/stores/pagination.ts
+++ b/apps/admin/src/stores/pagination.ts
@@ -1,0 +1,41 @@
+const PAGE_SIZE = 100;
+
+type PaginatedListFetcher<T> = (params: {
+  page: number;
+  size: number;
+}) => Promise<{
+  data?: {
+    data?: {
+      list?: T[];
+      total?: number;
+    };
+  };
+}>;
+
+export const fetchAllPaginated = async <T>(
+  fetchPage: PaginatedListFetcher<T>
+): Promise<T[]> => {
+  const firstResponse = await fetchPage({ page: 1, size: PAGE_SIZE });
+  const firstPage = firstResponse.data?.data;
+  const firstList = firstPage?.list || [];
+  const total = firstPage?.total || firstList.length;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  if (totalPages <= 1) {
+    return firstList;
+  }
+
+  const remainingResponses = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, index) =>
+      fetchPage({ page: index + 2, size: PAGE_SIZE })
+    )
+  );
+
+  const items = [...firstList];
+
+  for (const response of remainingResponses) {
+    items.push(...(response.data?.data?.list || []));
+  }
+
+  return items;
+};

--- a/apps/admin/src/stores/server.ts
+++ b/apps/admin/src/stores/server.ts
@@ -1,5 +1,6 @@
 import { filterServerList } from "@workspace/ui/services/admin/server";
 import { create } from "zustand";
+import { fetchAllPaginated } from "./pagination";
 
 interface ServerState {
   // Data
@@ -35,9 +36,9 @@ export const useServerStore = create<ServerState>((set, get) => ({
 
     set({ loading: true });
     try {
-      const { data } = await filterServerList({ page: 1, size: 999_999_999 });
+      const servers = await fetchAllPaginated(filterServerList);
       set({
-        servers: data?.data?.list || [],
+        servers,
         loaded: true,
       });
     } catch (_error) {

--- a/apps/admin/src/stores/subscribe.ts
+++ b/apps/admin/src/stores/subscribe.ts
@@ -1,5 +1,6 @@
 import { getSubscribeList } from "@workspace/ui/services/admin/subscribe";
 import { create } from "zustand";
+import { fetchAllPaginated } from "./pagination";
 
 interface SubscribeState {
   // Data
@@ -29,9 +30,9 @@ export const useSubscribeStore = create<SubscribeState>((set, get) => ({
 
     set({ loading: true });
     try {
-      const { data } = await getSubscribeList({ page: 1, size: 999_999_999 });
+      const subscribes = await fetchAllPaginated(getSubscribeList);
       set({
-        subscribes: data?.data?.list || [],
+        subscribes,
         loaded: true,
       });
     } catch (_error) {


### PR DESCRIPTION
## Summary
- replace oversized admin lookup requests with paginated loading using the backend page size limit
- apply the shared pagination helper to subscribe, node, and server stores

Closes #115

## Verification
- bun x biome check apps/admin/src/stores/subscribe.ts apps/admin/src/stores/node.ts apps/admin/src/stores/server.ts apps/admin/src/stores/pagination.ts
- bun run --filter ppanel-admin-web build

Note: `bun run --filter ppanel-admin-web check` currently fails on pre-existing issues in `apps/admin/src/sections/user/index.tsx`, outside this change.