### PR TITLE
fix(ui): remove unsupported 200 page size

### DIFF
--- a/packages/ui/src/composed/pro-list/pagination.tsx
+++ b/packages/ui/src/composed/pro-list/pagination.tsx
@@ -45,7 +45,7 @@ export function Pagination<TData>({ table }: PaginationProps<TData>) {
               <SelectValue placeholder={table.getState().pagination.pageSize} />
             </SelectTrigger>
             <SelectContent side="top">
-              {[10, 20, 50, 100, 200].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <SelectItem key={pageSize} value={`${pageSize}`}>
                   {pageSize}
                 </SelectItem>

--- a/packages/ui/src/composed/pro-table/pagination.tsx
+++ b/packages/ui/src/composed/pro-table/pagination.tsx
@@ -45,7 +45,7 @@ export function Pagination<TData>({ table }: PaginationProps<TData>) {
               <SelectValue placeholder={table.getState().pagination.pageSize} />
             </SelectTrigger>
             <SelectContent side="top">
-              {[10, 20, 50, 100, 200].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <SelectItem key={pageSize} value={`${pageSize}`}>
                   {pageSize}
                 </SelectItem>


### PR DESCRIPTION
## Summary
- remove the unsupported 200 page-size option from ProTable pagination
- remove the unsupported 200 page-size option from ProList pagination
- keep frontend selectable page sizes within the backend size <= 100 contract

## Verification
- bun --filter @workspace/ui check

Closes #115