### PR TITLE
fix(admin): add ticket status filter options

### DIFF
--- a/apps/admin/src/sections/ticket/index.tsx
+++ b/apps/admin/src/sections/ticket/index.tsx
@@ -157,7 +157,19 @@ export default function Page() {
             placeholder: t("status.0", "Status"),
             options: [
               {
-                label: t("close", "Close"),
+                label: t("status.1", "Pending Follow-up"),
+                value: "1",
+              },
+              {
+                label: t("status.2", "Pending Reply"),
+                value: "2",
+              },
+              {
+                label: t("status.3", "Resolved"),
+                value: "3",
+              },
+              {
+                label: t("status.4", "Closed"),
                 value: "4",
               },
             ],


### PR DESCRIPTION
## Summary\n- Add all ticket statuses to the admin ticket status filter\n- Use existing ticket status i18n keys for filter labels\n\nCloses #121\n\n## Verification\n- bun x biome lint apps/admin/src/sections/ticket/index.tsx\n- bun run lint (fails on existing unrelated apps/admin/src/sections/user/index.tsx noUselessUndefined issues)