### PR TITLE
fix(user): hide expired subscription reset actions

### DIFF
--- a/apps/user/src/sections/user/dashboard/content.tsx
+++ b/apps/user/src/sections/user/dashboard/content.tsx
@@ -228,7 +228,6 @@ export default function Content() {
             return (
               <Card
                 className={cn("relative", {
-                  "relative opacity-80 grayscale": isActuallyExpired,
                   "relative hidden opacity-60 blur-[0.3px] grayscale":
                     item.status === 4,
                 })}
@@ -272,7 +271,11 @@ export default function Content() {
                   </div>
                 )}
                 <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 space-y-0">
-                  <CardTitle className="font-medium">
+                  <CardTitle
+                    className={cn("font-medium", {
+                      "opacity-80 grayscale": isActuallyExpired,
+                    })}
+                  >
                     {item.subscribe.name}
                     <p className="mt-1 text-foreground/50 text-sm">
                       {t("expireAt", "Expires At")}:{" "}
@@ -283,48 +286,52 @@ export default function Content() {
                   </CardTitle>
                   {item.status !== 4 && (
                     <div className="flex flex-wrap gap-2">
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button size="sm" variant="destructive">
-                            {t("resetSubscription", "Reset Subscription")}
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>
-                              {t("prompt", "Prompt")}
-                            </AlertDialogTitle>
-                            <AlertDialogDescription>
-                              {t(
-                                "confirmResetSubscription",
-                                "Are you sure you want to reset your subscription?"
-                              )}
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>
-                              {t("cancel", "Cancel")}
-                            </AlertDialogCancel>
-                            <AlertDialogAction
-                              onClick={async () => {
-                                await resetUserSubscribeToken({
-                                  user_subscribe_id: item.id,
-                                });
-                                await refetch();
-                                toast.success(
-                                  t("resetSuccess", "Reset Success")
-                                );
-                              }}
-                            >
-                              {t("confirm", "Confirm")}
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                      <ResetTraffic
-                        id={item.id}
-                        replacement={item.subscribe.replacement}
-                      />
+                      {!isActuallyExpired && (
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button size="sm" variant="destructive">
+                              {t("resetSubscription", "Reset Subscription")}
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                {t("prompt", "Prompt")}
+                              </AlertDialogTitle>
+                              <AlertDialogDescription>
+                                {t(
+                                  "confirmResetSubscription",
+                                  "Are you sure you want to reset your subscription?"
+                                )}
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>
+                                {t("cancel", "Cancel")}
+                              </AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={async () => {
+                                  await resetUserSubscribeToken({
+                                    user_subscribe_id: item.id,
+                                  });
+                                  await refetch();
+                                  toast.success(
+                                    t("resetSuccess", "Reset Success")
+                                  );
+                                }}
+                              >
+                                {t("confirm", "Confirm")}
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      )}
+                      {!isActuallyExpired && (
+                        <ResetTraffic
+                          id={item.id}
+                          replacement={item.subscribe.replacement}
+                        />
+                      )}
                       {item.expire_time !== 0 && item.subscribe.sell && (
                         <Renewal id={item.id} subscribe={item.subscribe} />
                       )}
@@ -336,7 +343,11 @@ export default function Content() {
                     </div>
                   )}
                 </CardHeader>
-                <CardContent>
+                <CardContent
+                  className={cn({
+                    "opacity-80 grayscale": isActuallyExpired,
+                  })}
+                >
                   <ul className="grid grid-cols-2 gap-3 *:flex *:flex-col *:justify-between lg:grid-cols-4">
                     <li>
                       <span className="text-muted-foreground">

--- a/apps/user/src/sections/user/dashboard/content.tsx
+++ b/apps/user/src/sections/user/dashboard/content.tsx
@@ -391,12 +391,13 @@ export default function Content() {
                         {t("expirationDays", "Expiration Days")}
                       </span>
                       <span className="font-semibold text-2xl">
-                        {}
                         {item.expire_time
-                          ? differenceInDays(
-                              new Date(item.expire_time),
-                              new Date()
-                            ) || t("unknown", "Unknown")
+                          ? Math.abs(
+                              differenceInDays(
+                                new Date(item.expire_time),
+                                new Date()
+                              )
+                            )
                           : t("noLimit", "No Limit")}
                       </span>
                     </li>

--- a/packages/ui/src/utils/formatting.ts
+++ b/packages/ui/src/utils/formatting.ts
@@ -31,6 +31,6 @@ export function differenceInDays(
 ) {
   const diffInMs = differenceInMilliseconds(dateLeft, dateRight);
   const diffInDays = diffInMs / (1000 * 60 * 60 * 24);
-  if (diffInDays >= 1) return diffInDays.toFixed(0);
+  if (Math.abs(diffInDays) >= 1) return Math.trunc(diffInDays);
   return Number(diffInDays.toFixed(2));
 }

--- a/packages/ui/src/utils/formatting.ts
+++ b/packages/ui/src/utils/formatting.ts
@@ -28,9 +28,8 @@ export function formatDate(date?: Date | number, showTime = true) {
 export function differenceInDays(
   dateLeft: Date | number,
   dateRight: Date | number
-) {
+): number {
   const diffInMs = differenceInMilliseconds(dateLeft, dateRight);
   const diffInDays = diffInMs / (1000 * 60 * 60 * 24);
-  if (Math.abs(diffInDays) >= 1) return Math.trunc(diffInDays);
-  return Number(diffInDays.toFixed(2));
+  return Math.trunc(diffInDays);
 }


### PR DESCRIPTION
## Summary
- Hide reset subscription and reset traffic actions for actually expired subscriptions.
- Move the expired grayscale styling off the card root so renewal actions keep their normal appearance.
- Return integer day differences when the absolute day difference is at least one day.

## Verification
- bun x biome check apps/user/src/sections/user/dashboard/content.tsx packages/ui/src/utils/formatting.ts
- bun run check --filter=ppanel-user-web --filter=@workspace/ui

Closes #131