### PR TITLE
fix(ui): reset table pagination on filter change

### DIFF
--- a/packages/ui/src/composed/pro-table/column-filter.tsx
+++ b/packages/ui/src/composed/pro-table/column-filter.tsx
@@ -31,6 +31,7 @@ export function ColumnFilter<TData>({
       }
       return newFilters;
     });
+    table.setPageIndex(0);
   };
 
   const toDateInput = (d: Date) => {


### PR DESCRIPTION
## Summary
- reset ProTable pagination to the first page whenever a column filter changes
- ensures clearing the server search after an empty result reloads the default first page

Fixes #133

## Verification
- bun x biome check packages/ui/src/composed/pro-table/column-filter.tsx
- bun run check --filter=@workspace/ui --force