### PR TITLE
✨ feat: add Cloudflare Workers static assets deploy support

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,7 +1,10 @@
 # API base URL
+# Leave empty on Cloudflare Pages/Workers to use same-origin /v1/* proxy.
 VITE_API_BASE_URL=
 # API prefix path
 VITE_API_PREFIX=
+# Cloudflare runtime only (Pages Function / Worker), NOT a Vite build var:
+# API_BASE_URL=https://api.example.com
 
 # CDN URL for static assets
 VITE_CDN_URL=https://cdn.jsdmirror.com

--- a/apps/admin/cloudflare/api-proxy.ts
+++ b/apps/admin/cloudflare/api-proxy.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared Cloudflare API proxy for PPanel frontend.
+ *
+ * Used by Worker Static Assets and Cloudflare Pages Functions in this app.
+ * When VITE_API_BASE_URL is empty, the SPA calls same-origin `/v1/*`.
+ */
+
+export interface ProxyEnv {
+  API_BASE_URL?: string;
+}
+
+const DEFAULT_API_BASE_URL = "https://api.ppanel.dev";
+
+function resolveApiBase(env: ProxyEnv): string {
+  return (env.API_BASE_URL || DEFAULT_API_BASE_URL).replace(/\/$/, "");
+}
+
+function buildTargetUrl(request: Request, apiBase: string): string {
+  const url = new URL(request.url);
+  return `${apiBase}${url.pathname}${url.search}`;
+}
+
+function forwardHeaders(request: Request, apiBase: string): Headers {
+  const headers = new Headers(request.headers);
+  headers.set("Host", new URL(apiBase).host);
+  headers.delete("cf-connecting-ip");
+  headers.delete("cf-ipcountry");
+  headers.delete("cf-ray");
+  headers.delete("cf-visitor");
+  return headers;
+}
+
+function corsHeaders(origin: string): Headers {
+  const headers = new Headers();
+  headers.set("Access-Control-Allow-Origin", origin);
+  headers.set(
+    "Access-Control-Allow-Methods",
+    "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+  );
+  headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  headers.set("Access-Control-Max-Age", "86400");
+  return headers;
+}
+
+export async function proxyApiRequest(
+  request: Request,
+  env: ProxyEnv
+): Promise<Response> {
+  const url = new URL(request.url);
+  const origin = url.origin;
+  const apiBase = resolveApiBase(env);
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders(origin),
+    });
+  }
+
+  const targetUrl = buildTargetUrl(request, apiBase);
+  const headers = forwardHeaders(request, apiBase);
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: "follow",
+  };
+
+  if (
+    request.method !== "GET" &&
+    request.method !== "HEAD" &&
+    request.body !== null
+  ) {
+    init.body = request.body;
+  }
+
+  const upstream = await fetch(targetUrl, init);
+  const responseHeaders = new Headers(upstream.headers);
+
+  // Frontend stores auth in a client cookie from the JSON body.
+  // Avoid leaking backend Set-Cookie onto the frontend origin.
+  responseHeaders.delete("set-cookie");
+
+  const cors = corsHeaders(origin);
+  cors.forEach((value, key) => {
+    responseHeaders.set(key, value);
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  });
+}
+
+export function isApiPath(pathname: string): boolean {
+  return pathname === "/v1" || pathname.startsWith("/v1/");
+}

--- a/apps/admin/functions/v1/[[path]].ts
+++ b/apps/admin/functions/v1/[[path]].ts
@@ -1,9 +1,8 @@
 import { proxyApiRequest, type ProxyEnv } from "../../cloudflare/api-proxy";
 
 /**
- * Cloudflare Pages Function for monorepo-root deployments.
- * Prefer apps/admin/functions or apps/user/functions when the Pages
- * project root directory is set to those app folders.
+ * Cloudflare Pages Function: proxy same-origin `/v1/*` to the backend.
+ * Used when the Pages project root is this app directory.
  */
 export const onRequest: PagesFunction<ProxyEnv> = async (context) => {
   return proxyApiRequest(context.request, context.env);

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,6 +6,7 @@
     "dev": "vite --port 3001",
     "build": "vite build && tsc",
     "serve": "vite preview",
+    "deploy:cf": "bun x wrangler deploy",
     "lint": "biome lint",
     "check": "biome check",
     "i18n:extract": "i18next-cli extract",

--- a/apps/admin/public/_headers
+++ b/apps/admin/public/_headers
@@ -1,0 +1,9 @@
+# Cloudflare Pages / compatible static hosts
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/index.html
+  Cache-Control: no-cache

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -2,6 +2,13 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@workspace/typescript-config/base.json",
   "include": ["**/*.ts", "**/*.tsx", "src/types/**/*.d.ts"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "worker.ts",
+    "cloudflare/**",
+    "functions/**"
+  ],
   "compilerOptions": {
     "target": "ES2022",
     "jsx": "react-jsx",

--- a/apps/admin/worker.ts
+++ b/apps/admin/worker.ts
@@ -1,0 +1,21 @@
+import {
+  isApiPath,
+  proxyApiRequest,
+  type ProxyEnv,
+} from "./cloudflare/api-proxy";
+
+export interface Env extends ProxyEnv {
+  ASSETS: Fetcher;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { pathname } = new URL(request.url);
+
+    if (isApiPath(pathname)) {
+      return proxyApiRequest(request, env);
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/apps/admin/wrangler.toml
+++ b/apps/admin/wrangler.toml
@@ -1,0 +1,27 @@
+# Cloudflare Workers Static Assets deploy for PPanel Admin Web
+# Docs: https://developers.cloudflare.com/workers/static-assets/
+#
+# Build first:
+#   cd ../.. && bun install && bun run build --filter=ppanel-admin-web
+# Deploy:
+#   bun x wrangler deploy
+#
+# Runtime vars (set in dashboard or via `wrangler secret` / `wrangler vars`):
+#   API_BASE_URL = https://your-ppanel-backend.example.com
+
+name = "ppanel-admin-web"
+main = "./worker.ts"
+compatibility_date = "2026-08-01"
+workers_dev = true
+
+[assets]
+directory = "./dist"
+binding = "ASSETS"
+# SPA fallback for TanStack Router client routes
+not_found_handling = "single-page-application"
+# Only API traffic runs Worker code first; static assets stay free/edge-cached
+run_worker_first = ["/v1", "/v1/*"]
+
+[vars]
+# Override in Cloudflare dashboard for production backends
+API_BASE_URL = "https://api.ppanel.dev"

--- a/apps/user/.env.example
+++ b/apps/user/.env.example
@@ -1,7 +1,10 @@
 # API base URL
+# Leave empty on Cloudflare Pages/Workers to use same-origin /v1/* proxy.
 VITE_API_BASE_URL=
 # API prefix path
 VITE_API_PREFIX=
+# Cloudflare runtime only (Pages Function / Worker), NOT a Vite build var:
+# API_BASE_URL=https://api.example.com
 
 # CDN URL for static assets
 VITE_CDN_URL=https://cdn.jsdmirror.com

--- a/apps/user/cloudflare/api-proxy.ts
+++ b/apps/user/cloudflare/api-proxy.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared Cloudflare API proxy for PPanel frontend.
+ *
+ * Used by Worker Static Assets and Cloudflare Pages Functions in this app.
+ * When VITE_API_BASE_URL is empty, the SPA calls same-origin `/v1/*`.
+ */
+
+export interface ProxyEnv {
+  API_BASE_URL?: string;
+}
+
+const DEFAULT_API_BASE_URL = "https://api.ppanel.dev";
+
+function resolveApiBase(env: ProxyEnv): string {
+  return (env.API_BASE_URL || DEFAULT_API_BASE_URL).replace(/\/$/, "");
+}
+
+function buildTargetUrl(request: Request, apiBase: string): string {
+  const url = new URL(request.url);
+  return `${apiBase}${url.pathname}${url.search}`;
+}
+
+function forwardHeaders(request: Request, apiBase: string): Headers {
+  const headers = new Headers(request.headers);
+  headers.set("Host", new URL(apiBase).host);
+  headers.delete("cf-connecting-ip");
+  headers.delete("cf-ipcountry");
+  headers.delete("cf-ray");
+  headers.delete("cf-visitor");
+  return headers;
+}
+
+function corsHeaders(origin: string): Headers {
+  const headers = new Headers();
+  headers.set("Access-Control-Allow-Origin", origin);
+  headers.set(
+    "Access-Control-Allow-Methods",
+    "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+  );
+  headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  headers.set("Access-Control-Max-Age", "86400");
+  return headers;
+}
+
+export async function proxyApiRequest(
+  request: Request,
+  env: ProxyEnv
+): Promise<Response> {
+  const url = new URL(request.url);
+  const origin = url.origin;
+  const apiBase = resolveApiBase(env);
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders(origin),
+    });
+  }
+
+  const targetUrl = buildTargetUrl(request, apiBase);
+  const headers = forwardHeaders(request, apiBase);
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: "follow",
+  };
+
+  if (
+    request.method !== "GET" &&
+    request.method !== "HEAD" &&
+    request.body !== null
+  ) {
+    init.body = request.body;
+  }
+
+  const upstream = await fetch(targetUrl, init);
+  const responseHeaders = new Headers(upstream.headers);
+
+  // Frontend stores auth in a client cookie from the JSON body.
+  // Avoid leaking backend Set-Cookie onto the frontend origin.
+  responseHeaders.delete("set-cookie");
+
+  const cors = corsHeaders(origin);
+  cors.forEach((value, key) => {
+    responseHeaders.set(key, value);
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  });
+}
+
+export function isApiPath(pathname: string): boolean {
+  return pathname === "/v1" || pathname.startsWith("/v1/");
+}

--- a/apps/user/functions/v1/[[path]].ts
+++ b/apps/user/functions/v1/[[path]].ts
@@ -1,9 +1,8 @@
 import { proxyApiRequest, type ProxyEnv } from "../../cloudflare/api-proxy";
 
 /**
- * Cloudflare Pages Function for monorepo-root deployments.
- * Prefer apps/admin/functions or apps/user/functions when the Pages
- * project root directory is set to those app folders.
+ * Cloudflare Pages Function: proxy same-origin `/v1/*` to the backend.
+ * Used when the Pages project root is this app directory.
  */
 export const onRequest: PagesFunction<ProxyEnv> = async (context) => {
   return proxyApiRequest(context.request, context.env);

--- a/apps/user/package.json
+++ b/apps/user/package.json
@@ -6,6 +6,7 @@
     "dev": "vite --port 3000",
     "build": "vite build && tsc",
     "serve": "vite preview",
+    "deploy:cf": "bun x wrangler deploy",
     "lint": "biome lint",
     "check": "biome check",
     "test": "vitest run",

--- a/apps/user/public/_headers
+++ b/apps/user/public/_headers
@@ -1,0 +1,9 @@
+# Cloudflare Pages / compatible static hosts
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/index.html
+  Cache-Control: no-cache

--- a/apps/user/tsconfig.json
+++ b/apps/user/tsconfig.json
@@ -2,6 +2,13 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@workspace/typescript-config/base.json",
   "include": ["**/*.ts", "**/*.tsx", "src/types/**/*.d.ts"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "worker.ts",
+    "cloudflare/**",
+    "functions/**"
+  ],
   "compilerOptions": {
     "target": "ES2022",
     "jsx": "react-jsx",

--- a/apps/user/worker.ts
+++ b/apps/user/worker.ts
@@ -1,0 +1,21 @@
+import {
+  isApiPath,
+  proxyApiRequest,
+  type ProxyEnv,
+} from "./cloudflare/api-proxy";
+
+export interface Env extends ProxyEnv {
+  ASSETS: Fetcher;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { pathname } = new URL(request.url);
+
+    if (isApiPath(pathname)) {
+      return proxyApiRequest(request, env);
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/apps/user/wrangler.toml
+++ b/apps/user/wrangler.toml
@@ -1,0 +1,27 @@
+# Cloudflare Workers Static Assets deploy for PPanel User Web
+# Docs: https://developers.cloudflare.com/workers/static-assets/
+#
+# Build first:
+#   cd ../.. && bun install && bun run build --filter=ppanel-user-web
+# Deploy:
+#   bun x wrangler deploy
+#
+# Runtime vars (set in dashboard or via `wrangler secret` / `wrangler vars`):
+#   API_BASE_URL = https://your-ppanel-backend.example.com
+
+name = "ppanel-user-web"
+main = "./worker.ts"
+compatibility_date = "2026-08-01"
+workers_dev = true
+
+[assets]
+directory = "./dist"
+binding = "ASSETS"
+# SPA fallback for TanStack Router client routes
+not_found_handling = "single-page-application"
+# Only API traffic runs Worker code first; static assets stay free/edge-cached
+run_worker_first = ["/v1", "/v1/*"]
+
+[vars]
+# Override in Cloudflare dashboard for production backends
+API_BASE_URL = "https://api.ppanel.dev"

--- a/cloudflare/api-proxy.ts
+++ b/cloudflare/api-proxy.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared Cloudflare API proxy for monorepo-root Pages deployments.
+ * App-scoped copies live under apps/admin/cloudflare and apps/user/cloudflare.
+ */
+
+export interface ProxyEnv {
+  API_BASE_URL?: string;
+}
+
+const DEFAULT_API_BASE_URL = "https://api.ppanel.dev";
+
+function resolveApiBase(env: ProxyEnv): string {
+  return (env.API_BASE_URL || DEFAULT_API_BASE_URL).replace(/\/$/, "");
+}
+
+function buildTargetUrl(request: Request, apiBase: string): string {
+  const url = new URL(request.url);
+  return `${apiBase}${url.pathname}${url.search}`;
+}
+
+function forwardHeaders(request: Request, apiBase: string): Headers {
+  const headers = new Headers(request.headers);
+  headers.set("Host", new URL(apiBase).host);
+  headers.delete("cf-connecting-ip");
+  headers.delete("cf-ipcountry");
+  headers.delete("cf-ray");
+  headers.delete("cf-visitor");
+  return headers;
+}
+
+function corsHeaders(origin: string): Headers {
+  const headers = new Headers();
+  headers.set("Access-Control-Allow-Origin", origin);
+  headers.set(
+    "Access-Control-Allow-Methods",
+    "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+  );
+  headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  headers.set("Access-Control-Max-Age", "86400");
+  return headers;
+}
+
+export async function proxyApiRequest(
+  request: Request,
+  env: ProxyEnv
+): Promise<Response> {
+  const url = new URL(request.url);
+  const origin = url.origin;
+  const apiBase = resolveApiBase(env);
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders(origin),
+    });
+  }
+
+  const targetUrl = buildTargetUrl(request, apiBase);
+  const headers = forwardHeaders(request, apiBase);
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: "follow",
+  };
+
+  if (
+    request.method !== "GET" &&
+    request.method !== "HEAD" &&
+    request.body !== null
+  ) {
+    init.body = request.body;
+  }
+
+  const upstream = await fetch(targetUrl, init);
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete("set-cookie");
+
+  const cors = corsHeaders(origin);
+  cors.forEach((value, key) => {
+    responseHeaders.set(key, value);
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  });
+}
+
+export function isApiPath(pathname: string): boolean {
+  return pathname === "/v1" || pathname.startsWith("/v1/");
+}

--- a/docs/guide/separation/frontend.md
+++ b/docs/guide/separation/frontend.md
@@ -213,29 +213,110 @@ Add in Netlify console under Site settings → Build & deploy → Environment:
 
 ### Method 4: Deploy with Cloudflare Pages
 
+This monorepo already ships Cloudflare Pages Functions under each app
+(`apps/admin/functions`, `apps/user/functions`) plus SPA `_redirects` /
+`_headers`. When `VITE_API_BASE_URL` is empty, the SPA calls same-origin
+`/v1/*`, and the Pages Function proxies those requests to your backend.
+
 #### 1. Connect GitHub Repository
 
 Login to Cloudflare Dashboard → Workers & Pages → Create application → Pages → Connect to Git
 
 #### 2. Configure Build Settings
 
+Paths below are relative to the selected **Root directory**.
+
 **Admin Web**:
 - **Framework preset**: None
-- **Build command**: `cd .. && bun install && cd apps/admin && bun run build`
-- **Build output directory**: `apps/admin/dist`
 - **Root directory**: `apps/admin`
+- **Build command**: `cd ../.. && bun install && bun run build --filter=ppanel-admin-web`
+- **Build output directory**: `dist`
 
 **User Web**:
 - **Framework preset**: None
-- **Build command**: `cd .. && bun install && cd apps/user && bun run build`
-- **Build output directory**: `apps/user/dist`
 - **Root directory**: `apps/user`
+- **Build command**: `cd ../.. && bun install && bun run build --filter=ppanel-user-web`
+- **Build output directory**: `dist`
 
 #### 3. Configure Environment Variables
 
-Add in Settings → Environment variables:
-- `VITE_API_BASE_URL`
-- `VITE_CDN_URL`
+Build-time (Vite):
+- `VITE_API_BASE_URL` — leave empty to use same-origin `/v1/*` proxy
+- `VITE_API_PREFIX` — optional path prefix (default empty)
+- `VITE_CDN_URL` — optional
+
+Runtime (Pages Function proxy):
+- `API_BASE_URL` — real PPanel backend origin, e.g. `https://api.example.com`
+
+> Do not put secrets into `VITE_*` variables. Anything prefixed with `VITE_`
+> is embedded into the browser bundle.
+
+### Method 5: Deploy with Cloudflare Workers (Static Assets)
+
+Official one-click targets today focus on Vercel/Netlify. This repository
+also includes first-class **Workers Static Assets** configs:
+
+| App | Config | Worker entry |
+| --- | --- | --- |
+| Admin | `apps/admin/wrangler.toml` | `apps/admin/worker.ts` |
+| User | `apps/user/wrangler.toml` | `apps/user/worker.ts` |
+
+Shared proxy logic lives in each app under `cloudflare/api-proxy.ts`
+(and monorepo-root `cloudflare/api-proxy.ts` for root Pages deploys).
+
+#### 1. Build
+
+```bash
+# from monorepo root
+bun install
+bun run build --filter=ppanel-admin-web
+# or
+bun run build --filter=ppanel-user-web
+```
+
+#### 2. Login and deploy
+
+```bash
+# Admin
+cd apps/admin
+bun x wrangler login
+bun x wrangler deploy
+# or: bun run deploy:cf
+
+# User
+cd apps/user
+bun x wrangler login
+bun x wrangler deploy
+```
+
+#### 3. Configure backend proxy
+
+Leave frontend build env empty so API calls stay same-origin:
+
+```bash
+# apps/admin/.env / apps/user/.env (build time)
+VITE_API_BASE_URL=
+VITE_API_PREFIX=
+```
+
+Set the Worker/Pages runtime backend:
+
+```bash
+# optional CLI override
+bun x wrangler deploy --var API_BASE_URL:https://api.example.com
+```
+
+Or set `API_BASE_URL` in the Cloudflare dashboard for the Worker.
+
+#### 4. What the Worker config does
+
+- Serves the Vite `dist/` assets from the edge
+- SPA fallback via `not_found_handling = "single-page-application"`
+- Runs Worker code only for `/v1` and `/v1/*` (`run_worker_first`)
+- Proxies those API requests to `API_BASE_URL`
+
+This matches Cloudflare's current Workers Static Assets model and avoids
+hosting the SPA as a traditional Node server.
 
 ## Self-Hosted Server Deployment
 

--- a/docs/zh/guide/separation/frontend.md
+++ b/docs/zh/guide/separation/frontend.md
@@ -213,29 +213,109 @@ netlify deploy --prod --dir=dist
 
 ### 方式四：使用 Cloudflare Pages
 
+本仓库已为各应用提供 Cloudflare Pages Functions
+（`apps/admin/functions`、`apps/user/functions`）以及 SPA 所需的
+`_redirects` / `_headers`。当 `VITE_API_BASE_URL` 为空时，前端会请求
+同源 `/v1/*`，由 Pages Function 代理到真实后端。
+
 #### 1. 连接 GitHub 仓库
 
 登录 Cloudflare Dashboard → Workers & Pages → Create application → Pages → Connect to Git
 
 #### 2. 配置构建设置
 
+下列路径均相对于所选 **Root directory**。
+
 **管理端**：
 - **Framework preset**: None
-- **Build command**: `cd .. && bun install && cd apps/admin && bun run build`
-- **Build output directory**: `apps/admin/dist`
 - **Root directory**: `apps/admin`
+- **Build command**: `cd ../.. && bun install && bun run build --filter=ppanel-admin-web`
+- **Build output directory**: `dist`
 
 **用户端**：
 - **Framework preset**: None
-- **Build command**: `cd .. && bun install && cd apps/user && bun run build`
-- **Build output directory**: `apps/user/dist`
 - **Root directory**: `apps/user`
+- **Build command**: `cd ../.. && bun install && bun run build --filter=ppanel-user-web`
+- **Build output directory**: `dist`
 
 #### 3. 配置环境变量
 
-在 Settings → Environment variables 中添加：
-- `VITE_API_BASE_URL`
-- `VITE_CDN_URL`
+构建期（Vite）：
+- `VITE_API_BASE_URL` — 留空则走同源 `/v1/*` 代理
+- `VITE_API_PREFIX` — 可选路径前缀（默认空）
+- `VITE_CDN_URL` — 可选
+
+运行期（Pages Function 代理）：
+- `API_BASE_URL` — 真实 PPanel 后端源站，例如 `https://api.example.com`
+
+> 不要把密钥写进 `VITE_*`。所有 `VITE_` 前缀变量都会打进浏览器包。
+
+### 方式五：使用 Cloudflare Workers（Static Assets）
+
+官方一键部署目前主要覆盖 Vercel/Netlify。本仓库额外提供了可用的
+**Workers Static Assets** 配置：
+
+| 应用 | 配置 | Worker 入口 |
+| --- | --- | --- |
+| 管理端 | `apps/admin/wrangler.toml` | `apps/admin/worker.ts` |
+| 用户端 | `apps/user/wrangler.toml` | `apps/user/worker.ts` |
+
+共享代理逻辑位于各应用的 `cloudflare/api-proxy.ts`
+（monorepo 根目录也保留一份供根级 Pages 部署使用）。
+
+#### 1. 构建
+
+```bash
+# 在 monorepo 根目录
+bun install
+bun run build --filter=ppanel-admin-web
+# 或
+bun run build --filter=ppanel-user-web
+```
+
+#### 2. 登录并部署
+
+```bash
+# 管理端
+cd apps/admin
+bun x wrangler login
+bun x wrangler deploy
+# 或: bun run deploy:cf
+
+# 用户端
+cd apps/user
+bun x wrangler login
+bun x wrangler deploy
+```
+
+#### 3. 配置后端代理
+
+构建时保持前端 API 基址为空，让请求走同源：
+
+```bash
+# apps/admin/.env / apps/user/.env（构建期）
+VITE_API_BASE_URL=
+VITE_API_PREFIX=
+```
+
+运行时设置 Worker/Pages 后端：
+
+```bash
+# 可选 CLI 覆盖
+bun x wrangler deploy --var API_BASE_URL:https://api.example.com
+```
+
+也可在 Cloudflare 控制台为 Worker 设置 `API_BASE_URL`。
+
+#### 4. Worker 配置作用
+
+- 在边缘托管 Vite `dist/` 静态资源
+- 通过 `not_found_handling = "single-page-application"` 支持 SPA 路由
+- 仅对 `/v1` 与 `/v1/*` 优先执行 Worker（`run_worker_first`）
+- 将这些 API 请求代理到 `API_BASE_URL`
+
+该方案对齐 Cloudflare 当前 Workers Static Assets 模型，无需再挂
+Node 服务器托管前端。
 
 ## 自建服务器部署
 


### PR DESCRIPTION
## Summary
- Add first-class Cloudflare Workers Static Assets configs for admin/user SPAs (`wrangler.toml` + `worker.ts`)
- Fix Cloudflare Pages Function placement under each app root so monorepo `apps/admin|user` deploys can proxy same-origin `/v1/*`
- Document Workers deploy flow and correct Pages build/output paths
- Keep SPA `_redirects` and add `_headers` cache hints

## Why
Official docs previously focused on Vercel/Netlify. Pages notes existed, but there was no usable Workers Static Assets setup, and the root-only Pages Function did not work when the Pages root directory was an app folder.

## How it works
- Build-time: leave `VITE_API_BASE_URL` empty so the SPA calls same-origin `/v1/*`
- Runtime: Worker/Pages Function proxies `/v1/*` to `API_BASE_URL`
- SPA fallback uses `not_found_handling = "single-page-application"`
- Worker code runs first only for `/v1` and `/v1/*`

## Test plan
- [x] `bun run build --filter=ppanel-admin-web`
- [x] `bun run build --filter=ppanel-user-web`
- [x] `bun x wrangler deploy --dry-run` in `apps/admin`
- [x] `bun x wrangler deploy --dry-run` in `apps/user`
- [ ] Optional: live deploy with a real `API_BASE_URL`
