### PR TITLE
fix(request): surface the server's reason and stop the duplicate error toast

### DIFF
--- a/apps/admin/src/sections/auth/email/auth-form.tsx
+++ b/apps/admin/src/sections/auth/email/auth-form.tsx
@@ -59,12 +59,8 @@ export default function EmailAuthForm() {
             setType("login");
             break;
         }
-      } catch (error: any) {
-        toast.error(
-          error?.response?.data?.message ||
-            error?.message ||
-            "An error occurred"
-        );
+      } catch {
+        // The request layer already toasted the reason.
       }
     });
   };

--- a/apps/user/src/sections/auth/email/auth-form.tsx
+++ b/apps/user/src/sections/auth/email/auth-form.tsx
@@ -68,12 +68,8 @@ export default function EmailAuthForm() {
             setType("login");
             break;
         }
-      } catch (error: any) {
-        toast.error(
-          error?.response?.data?.message ||
-            error?.message ||
-            "An error occurred"
-        );
+      } catch {
+        // The request layer already toasted the reason.
       }
     });
   };

--- a/apps/user/src/sections/auth/phone/auth-form.tsx
+++ b/apps/user/src/sections/auth/phone/auth-form.tsx
@@ -68,12 +68,8 @@ export default function PhoneAuthForm() {
             setType("login");
             break;
         }
-      } catch (error: any) {
-        toast.error(
-          error?.response?.data?.message ||
-            error?.message ||
-            "An error occurred"
-        );
+      } catch {
+        // The request layer already toasted the reason.
       }
     });
   };

--- a/packages/ui/src/lib/request.ts
+++ b/packages/ui/src/lib/request.ts
@@ -5,15 +5,17 @@ import axios, { type InternalAxiosRequestConfig } from "axios";
 import { toast } from "sonner";
 
 function handleError(response: {
-  data?: { code?: number; message?: string };
+  data?: { code?: number; msg?: string; message?: string };
   config?: { skipErrorHandler?: boolean };
   message?: string;
-}) {
+}): string | undefined {
   const code = response.data?.code;
-  if (code && [40_002, 40_003, 40_004, 40_005].includes(code))
-    return window.logout();
-  if (response?.config?.skipErrorHandler) return;
-  if (!isBrowser()) return;
+  if (code && [40_002, 40_003, 40_004, 40_005].includes(code)) {
+    window.logout();
+    return;
+  }
+  const serverMessage = response.data?.msg || response.data?.message;
+  if (!isBrowser()) return serverMessage || response.message;
 
   const t = window.i18n.t;
 
@@ -162,14 +164,17 @@ function handleError(response: {
   };
 
   const message =
-    response.data?.message ||
     (code ? ERROR_MESSAGES[code] : undefined) ||
+    serverMessage ||
     t(
       "components:error.unknown",
       "An error occurred in the system, please try again later."
     );
 
+  if (response?.config?.skipErrorHandler) return message;
+
   toast.error(message);
+  return message;
 }
 
 const request = axios.create({
@@ -194,7 +199,7 @@ request.interceptors.response.use(
   (response) => {
     const { code } = response.data;
     if (code !== 200 && code !== 0) {
-      handleError({
+      const message = handleError({
         data: response.data,
         config: {
           skipErrorHandler: (response.config as { skipErrorHandler?: boolean })
@@ -202,7 +207,11 @@ request.interceptors.response.use(
         },
         message: response.statusText,
       });
-      throw response;
+      throw Object.assign(new Error(message ?? "Request failed"), {
+        code,
+        data: response.data,
+        response,
+      });
     }
     return response;
   },


### PR DESCRIPTION
Fixes #145

每一次业务错误都会叠加两个缺陷:先弹出正确的原因,紧接着被一个没有信息量的英文提示盖掉。

## 一、后端的原因从来没被读到

业务错误是 **HTTP 200 + body 携带错误码**,字段名是 `msg`:

```console
$ curl -s -X POST /api/v1/auth/login -d '{"email":"nonexistent@example.invalid","password":"x"}'
{"code":20002,"msg":"User does not exist"}
```

而 `handleError` 读的是 `response.data?.message` —— **永远是 undefined**。真正兜住错误提示的只有手工维护的 `ERROR_MESSAGES` 表。该表列了 36 个码,而 `pkg/xerr` 定义了 67 个,**剩下 30 个**(整个 `610xx` 订单段、`EmailExist`、`TelephoneExist`、`InviteCodeError`、`UserCommissionNotEnough`、`TelegramNotBound`)直接落到「系统发生错误,请稍后再试」,把后端已经发过来的准确原因丢掉了。

比如用户续费撞上 `61004 InsufficientOfPeriod`(周期不足),看到的是通用错误,既不知道原因也不知道该做什么。

改后的优先级:**表里有就用表里的**(已本地化)→ 没有就用后端 `msg` → 都没有才用通用兜底。这样以后后端新增错误码也不需要前端跟着维护这张表。

## 二、拦截器抛的是 response 对象

`throw response` 让 `catch (error)` 拿到的东西**既不是 Error 也不是 axios 错误**,于是三个登录表单里的 `error?.response?.data?.message || error?.message` 两级全部落空,弹出硬编码的 `"An error occurred"`,盖在 `handleError` 已经弹好的正确提示上。

现在抛的是真正的 `Error`,`message` 是解析好的文案,`code` / `data` / `response` 都挂在上面供需要 payload 的调用方使用。三个表单不再重复弹 —— **错误 toast 由请求层单一负责**,同时把文案返回出去,这样设了 `skipErrorHandler` 的调用方仍能自己渲染。

改动风险很小:仓库里 87 个 `catch` 只有 **3 个**真正读了 error 内容,而这 3 个正是本 PR 修的这三处,其余都是 `catch (_error)` 直接忽略。

## 验证

本分支单独跑 `bun --filter ppanel-user-web check`、`bun --filter ppanel-admin-web check` 与 `bun run build`,全部通过。