### PR TITLE
chore(automation): add webhook delivery dry runs

### DIFF
--- a/.github/workflows/openapi-adaptation.yml
+++ b/.github/workflows/openapi-adaptation.yml
@@ -2,6 +2,12 @@ name: openapi-adaptation
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Verify delivery without starting the automation agent
+        required: true
+        type: boolean
+        default: true
   push:
     branches: [main]
     paths:
@@ -11,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  notify-hermes:
+  notify-automation:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted develop automation
@@ -38,6 +44,7 @@ jobs:
           AUTOMATION_WEBHOOK_URL: ${{ secrets.AUTOMATION_WEBHOOK_URL }}
           AUTOMATION_WEBHOOK_SECRET: ${{ secrets.AUTOMATION_WEBHOOK_SECRET }}
           AUTOMATION_EVENT_TYPE: openapi.adapt
+          AUTOMATION_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_ACTION: ${{ github.event.action || '' }}
           GITHUB_DELIVERY: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/triage-automation.yml
+++ b/.github/workflows/triage-automation.yml
@@ -2,6 +2,20 @@ name: triage-automation
 
 on:
   workflow_dispatch:
+    inputs:
+      event_type:
+        description: Automation event to verify
+        required: true
+        type: choice
+        default: triage.issue
+        options:
+          - triage.issue
+          - triage.pull_request
+      dry_run:
+        description: Verify delivery without starting the automation agent
+        required: true
+        type: boolean
+        default: true
   issues:
     types: [opened, edited, reopened, labeled]
   issue_comment:
@@ -41,6 +55,8 @@ jobs:
         env:
           AUTOMATION_WEBHOOK_URL: ${{ secrets.AUTOMATION_WEBHOOK_URL }}
           AUTOMATION_WEBHOOK_SECRET: ${{ secrets.AUTOMATION_WEBHOOK_SECRET }}
+          AUTOMATION_EVENT_TYPE: ${{ github.event_name == 'workflow_dispatch' && inputs.event_type || '' }}
+          AUTOMATION_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_ACTION: ${{ github.event.action || '' }}
           GITHUB_DELIVERY: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/scripts/openapi-adaptation-workflow.test.mjs
+++ b/scripts/openapi-adaptation-workflow.test.mjs
@@ -9,6 +9,7 @@ const workflow = readFileSync(
 
 test("openapi adaptation workflow triggers only for main pushes that touch swagger JSON and manual reruns", () => {
   assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /dry_run:/);
   assert.match(workflow, /push:\n\s+branches: \[main\]/);
   assert.match(workflow, /paths:\n\s+- ['"]docs\/public\/swagger\/\*\.json['"]/);
   assert.doesNotMatch(workflow, /^\s+pull_request(?:_target)?:/m);
@@ -37,6 +38,7 @@ test("openapi adaptation workflow sends only automation webhook context and meta
     /AUTOMATION_WEBHOOK_SECRET: \$\{\{ secrets\.AUTOMATION_WEBHOOK_SECRET \}\}/
   );
   assert.match(workflow, /AUTOMATION_EVENT_TYPE: openapi\.adapt/);
+  assert.match(workflow, /AUTOMATION_DRY_RUN:/);
   assert.match(workflow, /GITHUB_EVENT_NAME: \$\{\{ github\.event_name \}\}/);
   assert.match(workflow, /GITHUB_EVENT_ACTION: \$\{\{ github\.event\.action \|\| '' \}\}/);
   assert.match(workflow, /GITHUB_DELIVERY: \$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/);

--- a/scripts/triage-webhook.mjs
+++ b/scripts/triage-webhook.mjs
@@ -17,8 +17,8 @@ const eventType =
   explicitEventType || (isPullRequest ? "triage.pull_request" : "triage.issue");
 
 const payload = {
-  routeId: "perfect-panel-frontend-triage",
   eventType,
+  dryRun: process.env.AUTOMATION_DRY_RUN === "true",
   repo: "perfect-panel/frontend",
   source: "github-actions",
   trigger: {

--- a/scripts/triage-webhook.test.mjs
+++ b/scripts/triage-webhook.test.mjs
@@ -60,7 +60,7 @@ async function withServer(handler) {
   const { port } = server.address();
   return {
     requests,
-    url: `http://127.0.0.1:${port}/webhook/hermes`,
+    url: `http://127.0.0.1:${port}/webhook`,
     close: () => new Promise((resolve) => server.close(resolve)),
   };
 }
@@ -147,6 +147,7 @@ test("supports explicit automation event type override for openapi adaptation wi
         AUTOMATION_WEBHOOK_URL: server.url,
         AUTOMATION_WEBHOOK_SECRET: secret,
         AUTOMATION_EVENT_TYPE: "openapi.adapt",
+        AUTOMATION_DRY_RUN: "true",
         GITHUB_EVENT_NAME: "push",
         GITHUB_EVENT_ACTION: "",
         GITHUB_DELIVERY: "delivery-openapi",
@@ -157,6 +158,7 @@ test("supports explicit automation event type override for openapi adaptation wi
     const [{ request, body }] = server.requests;
     const payload = JSON.parse(body);
     assert.equal(payload.eventType, "openapi.adapt");
+    assert.equal(payload.dryRun, true);
     assert.equal(payload.repo, "perfect-panel/frontend");
     assert.equal(payload.trigger.kind, "push");
     assert.equal(payload.trigger.eventName, "push");

--- a/scripts/triage-workflow.test.mjs
+++ b/scripts/triage-workflow.test.mjs
@@ -9,6 +9,8 @@ const workflow = readFileSync(
 
 test("triage workflow keeps existing issue, open comment, and manual triggers", () => {
   assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /event_type:/);
+  assert.match(workflow, /dry_run:/);
   assert.match(
     workflow,
     /issues:\n\s+types: \[opened, edited, reopened, labeled\]/
@@ -49,6 +51,8 @@ test("triage workflow uses automation secrets and delivery metadata, not BRIDGE 
     workflow,
     /AUTOMATION_WEBHOOK_SECRET: \$\{\{ secrets\.AUTOMATION_WEBHOOK_SECRET \}\}/
   );
+  assert.match(workflow, /AUTOMATION_EVENT_TYPE:/);
+  assert.match(workflow, /AUTOMATION_DRY_RUN:/);
   assert.match(
     workflow,
     /GITHUB_DELIVERY: \$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/


### PR DESCRIPTION
## Summary

- add safe dry-run inputs for triage and OpenAPI webhook delivery
- allow manual verification of issue and pull-request event routing
- keep agent execution disabled during delivery checks
- remove the remaining implementation-specific workflow job name

## Verification

- Node tests: 20 passed
- actionlint
- git diff --check