### PR TITLE
fix(admin): wrap long order transaction numbers

### DIFF
--- a/apps/admin/src/sections/order/index.tsx
+++ b/apps/admin/src/sections/order/index.tsx
@@ -111,14 +111,14 @@ export default function Order() {
                     <Display type="currency" value={order.amount} />
                   </Button>
                 </HoverCardTrigger>
-                <HoverCardContent>
+                <HoverCardContent className="w-auto max-w-[80vw]">
                   <div className="grid gap-3">
                     {order.trade_no && (
                       <>
                         <div className="font-semibold">
                           {t("tradeNo", "Transaction Number")}
                         </div>
-                        <span className="text-muted-foreground">
+                        <span className="break-all text-muted-foreground">
                           {order.trade_no}
                         </span>
                         <Separator className="my-2" />


### PR DESCRIPTION
## Summary

- let the order amount hover card size to its content within the viewport
- wrap long transaction numbers instead of allowing them to overflow

## Verification

- `bun run --filter ppanel-admin-web check`
- `bun run --filter ppanel-admin-web build`

Closes #146